### PR TITLE
Fix patreon gradient names (See: #13)

### DIFF
--- a/components/patreon/patreon-styles.ts
+++ b/components/patreon/patreon-styles.ts
@@ -53,14 +53,14 @@ export const patreonStyles = () => {
                 id: colorArray[3],
                 style: [
                     {
-                        background: `-webkit-linear-gradient(left, ${darkModeString})`,
+                        backgroundImage: `-webkit-linear-gradient(left, ${darkModeString})`,
                         WebkitBackgroundClip: "text",
                         backgroundClip: "text",
                         color: "transparent",
                         WebkitTextFillColor: "transparent",
                     },
                     {
-                        background: `-webkit-linear-gradient(left, ${lightModeString})`,
+                        backgroundImage: `-webkit-linear-gradient(left, ${lightModeString})`,
                         WebkitBackgroundClip: "text",
                         backgroundClip: "text",
                         color: "transparent",


### PR DESCRIPTION
- Fixes an issue with ``background-clip: text`` vanishing in the background shorthand property (#13 )