### PR TITLE
fixes #18 - implement reconnecting and pinging websocket

### DIFF
--- a/components/marathon/event-display.tsx
+++ b/components/marathon/event-display.tsx
@@ -1,6 +1,6 @@
-import useWebSocket from "react-use-websocket";
 import { useEffect, useState } from "react";
 import { MarathonEvent } from "./send-marathon-data-button";
+import { useReconnectWebsocket } from "../websocket/use-reconnect-websocket";
 
 interface ReceivedEvent {
     time: string;
@@ -15,8 +15,7 @@ export const EventDisplay = ({
     const [messages, setMessages] = useState([]);
     const [currentMessage, setCurrentMessage] = useState("");
 
-    const websocketUrl = `${process.env.NEXT_PUBLIC_WEBSOCKET_URL}?username=marathon-${session.username}`;
-    const { lastMessage } = useWebSocket(websocketUrl);
+    const lastMessage = useReconnectWebsocket(`marathon-${session.username}`);
 
     useEffect(() => {
         if (lastMessage !== null) {

--- a/components/websocket/use-reconnect-websocket.ts
+++ b/components/websocket/use-reconnect-websocket.ts
@@ -1,0 +1,35 @@
+import useWebSocket, { Options, ReadyState } from "react-use-websocket";
+import { useEffect } from "react";
+
+export const useReconnectWebsocket = (username?: string) => {
+    const options: Options = {
+        shouldReconnect: () => true,
+        retryOnError: true,
+        reconnectInterval: (attemptNumber) =>
+            Math.min(Math.pow(2, attemptNumber) * 1000, 10000),
+    };
+    const pingIntervalMinutes = 9;
+    let websocketUrl = process.env.NEXT_PUBLIC_WEBSOCKET_URL as string;
+
+    if (username) {
+        websocketUrl += `?username=${username}`;
+    }
+
+    const { lastMessage, sendMessage, readyState } = useWebSocket(
+        websocketUrl,
+        options
+    );
+
+    useEffect(() => {
+        if (readyState === ReadyState.OPEN) {
+            const interval = setInterval(
+                () => sendMessage(""),
+                pingIntervalMinutes * 60 * 1000
+            );
+
+            return () => clearInterval(interval);
+        }
+    }, [readyState]);
+
+    return lastMessage;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "react-switch": "^6.0.0",
         "react-timer-wrapper": "^0.4.1",
         "react-timezone-select": "^1.4.0",
-        "react-use-websocket": "^3.0.0",
+        "react-use-websocket": "^4.3.1",
         "styled-components": "^5.3.5",
         "swr": "^2.1.5",
         "victory": "^36.6.8",
@@ -6405,12 +6405,12 @@
       }
     },
     "node_modules/react-use-websocket": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-use-websocket/-/react-use-websocket-3.0.0.tgz",
-      "integrity": "sha512-BInlbhXYrODBPKIplDAmI0J1VPM+1KhCLN09o+dzgQ8qMyrYs4t5kEYmCrTqyRuMTmpahylHFZWQXpfYyDkqOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-use-websocket/-/react-use-websocket-4.3.1.tgz",
+      "integrity": "sha512-zHPLWrgcqydJaak2O5V9hiz4q2dwkwqNQqpgFVmSuPxLZdsZlnDs8DVHy3WtHH+A6ms/8aHIyX7+7ulOcrnR0Q==",
       "peerDependencies": {
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0"
+        "react": ">= 18.0.0",
+        "react-dom": ">= 18.0.0"
       }
     },
     "node_modules/readdirp": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "react-switch": "^6.0.0",
     "react-timer-wrapper": "^0.4.1",
     "react-timezone-select": "^1.4.0",
-    "react-use-websocket": "^3.0.0",
+    "react-use-websocket": "^4.3.1",
     "styled-components": "^5.3.5",
     "swr": "^2.1.5",
     "victory": "^36.6.8",

--- a/pages/[username].tsx
+++ b/pages/[username].tsx
@@ -20,9 +20,9 @@ import {
     LiveRun,
     LiveUserRun,
 } from "../components/live/live-user-run";
-import useWebSocket from "react-use-websocket";
 import Stats from "../components/user/stats";
 import { TwitchEmbed } from "../vendor/react-twitch-embed/dist/index";
+import { useReconnectWebsocket } from "../components/websocket/use-reconnect-websocket";
 
 export interface UserPageProps {
     runs: Run[];
@@ -54,9 +54,7 @@ const User = ({
     const [, forceUpdate] = useReducer((x) => x + 1, 0);
     const [liveRun, setLiveRun] = useState(liveData);
 
-    const { lastMessage } = useWebSocket(
-        `${process.env.NEXT_PUBLIC_WEBSOCKET_URL}?username=${username}`
-    );
+    const lastMessage = useReconnectWebsocket(username);
 
     useEffect(() => {
         if (lastMessage !== null) {

--- a/pages/[username]/[game]/[run].tsx
+++ b/pages/[username]/[game]/[run].tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import useWebSocket from "react-use-websocket";
 import { GetServerSideProps, GetServerSidePropsContext } from "next";
 import { AppContext } from "../../../common/app.context";
 import { getRun } from "../../../lib/get-run";
@@ -36,6 +35,7 @@ import {
     LiveUserRun,
 } from "../../../components/live/live-user-run";
 import { getLiveRunForUser } from "../../../lib/live-runs";
+import { useReconnectWebsocket } from "../../../components/websocket/use-reconnect-websocket";
 
 interface RunPageProps extends AppProps {
     run: Run;
@@ -86,9 +86,7 @@ const RunPage = ({
     const [gameTimeRuns, setGameTimeRuns] = useState(null);
     const [liveRun, setLiveRun] = useState(liveData);
 
-    const { lastMessage } = useWebSocket(
-        `${process.env.NEXT_PUBLIC_WEBSOCKET_URL}?username=${username}`
-    );
+    const lastMessage = useReconnectWebsocket(username);
 
     useEffect(() => {
         if (lastMessage !== null) {

--- a/pages/live.tsx
+++ b/pages/live.tsx
@@ -7,7 +7,6 @@ import {
     LiveRun,
     LiveUserRun,
 } from "../components/live/live-user-run";
-import useWebSocket from "react-use-websocket";
 import React, { useEffect, useState } from "react";
 import searchStyles from "../components/css/Search.module.scss";
 import styles from "../components/css/Games.module.scss";
@@ -23,6 +22,7 @@ import {
     DurationAsTimer,
 } from "../components/util/datetime";
 import Timer from "../vendor/timer/src/index";
+import { useReconnectWebsocket } from "../components/websocket/use-reconnect-websocket";
 
 export type LiveDataMap = {
     [user: string]: LiveRun;
@@ -48,7 +48,7 @@ export const Live = ({
     const [currentlyViewing, setCurrentlyViewing] = useState(
         getRecommendedStream(liveDataMap, username)
     );
-    const { lastMessage } = useWebSocket(process.env.NEXT_PUBLIC_WEBSOCKET_URL);
+    const lastMessage = useReconnectWebsocket();
 
     useEffect(() => {
         if (lastMessage !== null) {

--- a/pages/marathon.tsx
+++ b/pages/marathon.tsx
@@ -3,10 +3,10 @@ import { LiveDataMap, liveRunArrayToMap } from "./live";
 import { GetServerSideProps } from "next";
 import { LiveRun } from "../components/live/live-user-run";
 import { getAllLiveRuns } from "../lib/live-runs";
-import useWebSocket from "react-use-websocket";
 import styles from "../components/css/Search.module.scss";
 import MarathonRun from "../components/marathon/marathon-run";
 import { Col, Row } from "react-bootstrap";
+import { useReconnectWebsocket } from "../components/websocket/use-reconnect-websocket";
 
 export const Marathon = ({
     liveDataMap,
@@ -19,7 +19,7 @@ export const Marathon = ({
     const [selectedUser, setSelectedUser] = useState("");
     const [currentUserData, setCurrentUserData] = useState();
 
-    const { lastMessage } = useWebSocket(process.env.NEXT_PUBLIC_WEBSOCKET_URL);
+    const lastMessage = useReconnectWebsocket();
 
     useEffect(() => {
         if (lastMessage !== null) {

--- a/pages/tournaments/[tournament].tsx
+++ b/pages/tournaments/[tournament].tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import useWebSocket from "react-use-websocket";
 import { Button, Col, Image, Row, Tab, Tabs } from "react-bootstrap";
 import { LiveRun, LiveUserRun } from "../../components/live/live-user-run";
 import { RecommendedStream } from "../../components/live/recommended-stream";
@@ -22,6 +21,7 @@ import {
 } from "../../components/tournament/tournament-info";
 import { TournamentRuns } from "../../components/tournament/tournament-runs";
 import { TournamentStandings } from "../../components/tournament/tournament-standings";
+import { useReconnectWebsocket } from "../../components/websocket/use-reconnect-websocket";
 
 export const GenericTournament = ({
     liveDataMap,
@@ -65,7 +65,7 @@ export const GenericTournament = ({
     );
 
     const eventStarted = new Date() > new Date(tournament.startDate);
-    const { lastMessage } = useWebSocket(process.env.NEXT_PUBLIC_WEBSOCKET_URL);
+    const lastMessage = useReconnectWebsocket();
 
     useEffect(() => {
         if (lastMessage !== null) {


### PR DESCRIPTION
Creates a new hook that wraps `useWebsocket` that does two things:

- Reconnects automatically with exponential backoff after disconnect
- Pings the server every 9 minutes to prevent the server automatically closing

Both to deal with AWS hard limits: https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html