### PR TITLE
Added base url to env vars and fixed twitch login

### DIFF
--- a/.env
+++ b/.env
@@ -10,6 +10,7 @@ NEXT_PUBLIC_SET_LIVE_RUN_API_URL=https://dspc6ekj2gjkfp44cjaffhjeue0fbswr.lambda
 NEXT_PUBLIC_PATREON_LOGIN_URL=https://xmrardyskezhapzs76j6qr6sku0fuhlp.lambda-url.eu-west-1.on.aws
 NEXT_PUBLIC_PATREON_API_URL=https://24lsraymnngdeivyuvkpnopele0kjnus.lambda-url.eu-west-1.on.aws
 NEXT_PUBLIC_MEDIA_URL=https://d73zqe3h0v0mi.cloudfront.net/therun
+NEXT_PUBLIC_BASE_URL=http://localhost:3000
 
 TWITCH_OAUTH_SECRET=
 TWITCH_OAUTH_CLIENT_ID=

--- a/.env
+++ b/.env
@@ -11,6 +11,7 @@ NEXT_PUBLIC_PATREON_LOGIN_URL=https://xmrardyskezhapzs76j6qr6sku0fuhlp.lambda-ur
 NEXT_PUBLIC_PATREON_API_URL=https://24lsraymnngdeivyuvkpnopele0kjnus.lambda-url.eu-west-1.on.aws
 NEXT_PUBLIC_MEDIA_URL=https://d73zqe3h0v0mi.cloudfront.net/therun
 NEXT_PUBLIC_BASE_URL=http://localhost:3000
+NEXT_PUBLIC_VERCEL_URL=${VERCEL_URL}
 
 TWITCH_OAUTH_SECRET=
 TWITCH_OAUTH_CLIENT_ID=

--- a/components/twitch/TwitchLoginButton.tsx
+++ b/components/twitch/TwitchLoginButton.tsx
@@ -4,8 +4,6 @@ import Image from "next/image";
 import styles from "../css/TwitchLoginButton.module.scss";
 import { AppContext } from "../../common/app.context";
 
-export const clientId = process.env.TWITCH_OAUTH_CLIENT_ID;
-
 export const TwitchLoginButton = ({
     username,
     picture,
@@ -15,6 +13,7 @@ export const TwitchLoginButton = ({
     picture?: string;
     redirect: string;
 }) => {
+    const clientId = process.env.TWITCH_OAUTH_CLIENT_ID;
     const { baseUrl = "https://therun.gg" } = React.useContext(AppContext);
     if (username)
         return (
@@ -58,7 +57,10 @@ export const TwitchLoginButton = ({
             userinfo: { preferred_username: null, picture: null },
         }),
     });
-    const url = new URL(`${twitchAuthURL}?${params}`);
+    const url = new URL(
+        `${twitchAuthURL}?${decodeURIComponent(params.toString())}`
+    );
+
     return (
         <Nav.Link href={url.href}>
             <Button

--- a/components/twitch/get-session-data.ts
+++ b/components/twitch/get-session-data.ts
@@ -9,7 +9,7 @@ export const getSessionData = async (
 ) => {
     const { req, res } = context;
     const { cookies } = req ? req : { cookies: undefined };
-    const { code } = context.query;
+    const code = context.query ? (context.query["code"] as string) : null;
 
     let data = {};
 

--- a/components/twitch/is-channel-live.ts
+++ b/components/twitch/is-channel-live.ts
@@ -1,6 +1,5 @@
-import { clientId } from "./TwitchLoginButton";
-
 export const isChannelLive = (oauthToken: string, channelName: string) => {
+    const clientId = process.env.TWITCH_OAUTH_CLIENT_ID;
     return fetch(
         `https://api.twitch.tv/helix/streams?user_login=${channelName}`,
         {

--- a/components/twitch/login-with-twitch.ts
+++ b/components/twitch/login-with-twitch.ts
@@ -1,7 +1,4 @@
-import { clientId } from "./TwitchLoginButton";
 import { getUserInfo } from "./get-user-info";
-
-export const clientSecret = process.env.TWITCH_OAUTH_SECRET;
 
 export interface LoginWithTwitchResult {
     loginData: LoginData;
@@ -23,6 +20,8 @@ export const loginWithTwitch = async (
     baseUrl: string,
     code: string
 ): Promise<LoginWithTwitchResult> => {
+    const clientId = process.env.TWITCH_OAUTH_CLIENT_ID;
+    const clientSecret = process.env.TWITCH_OAUTH_SECRET;
     const uri =
         `https://id.twitch.tv/oauth2/token` +
         `?client_id=${clientId}&client_secret=${clientSecret}&code=${code}&grant_type=authorization_code` +


### PR DESCRIPTION
Did two things at once, sorry!

1: Get baseUrl from environment. Is now gotten in function `getBaseUrl` in _app.tsx and set to context from there

2: Fixed twitch login - params should not be url-encoded, the client_id was retrieved incorrectly (env var needs to be explicitly retrieved) and baseUrl was not available in context of the Layout