### PR TITLE
Disable autoplay on twitch embeds on initial load

### DIFF
--- a/src/components/live/recommended-stream.tsx
+++ b/src/components/live/recommended-stream.tsx
@@ -129,6 +129,7 @@ export const RecommendedStream = ({
                         height={"100%"}
                         muted
                         withChat={false}
+                        autoplay={false}
                     />
                 </Col>
                 <Col

--- a/src/pages/[username].tsx
+++ b/src/pages/[username].tsx
@@ -252,6 +252,7 @@ const User = ({
                             height={"800px"}
                             muted
                             withChat={true}
+                            autoplay={false}
                         />
                     </Tab>
                 </Tabs>


### PR DESCRIPTION
This PR serves the purpose of improving load of the page on mobile by **disabling the autoplay in the twitch embeds** as users usually want to save their bandwitdh when using their mobile data.