### PR TITLE
Rework scrollbar styles

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -34,6 +34,8 @@
 
     --image-accordion-button: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23212529'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
     --image-accordion-button-collapse: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='darkgreen'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
+
+    --scrollbar-thumb-bg: #c1c1c1;
 }
 
 [data-theme="dark"] {
@@ -69,6 +71,8 @@
     --image-accordion-button-collapse: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='darkgreen'%3e%3cpath fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/%3e%3c/svg%3e");
 
     --bs-border-color: var(--color-border);
+
+    --scrollbar-thumb-bg: #585858;
 }
 
 html {
@@ -587,4 +591,31 @@ abbr {
 .link-without-style:hover {
     color: inherit !important;
     text-decoration: none !important;
+}
+
+body * {
+    -ms-overflow-style: auto;
+    scrollbar-color: var(--scrollbar-thumb-bg) var(--color-tertiary);
+    scrollbar-width: thin;
+}
+
+body *::-webkit-scrollbar-track {
+    background-color: var(--color-tertiary);
+    border: 0 solid var(--color-tertiary);
+}
+
+body *::-webkit-scrollbar-thumb {
+    background-color: var(--scrollbar-thumb-bg);
+    border: 0 solid var(--color-tertiary);
+    min-height: 2rem;
+    border-radius: 0.625rem;
+}
+
+body *::-webkit-scrollbar-corner {
+    background-color: var(--color-tertiary);
+}
+
+body *::-webkit-scrollbar {
+    width: 0.625rem;
+    height: 0.625rem;
 }


### PR DESCRIPTION
 ## Description

This PR introduces new scrollbar styles for all components of therun.gg (excluding the html scrollbar)

See Issue #84 for more information

## Browsers and testing
They have been tested under:
- Firefox (Border-radius for the thumb doesn't work)
- Chromium Browsers
- Safari back to Big Sur latest Chromium


## Issues
- The border-radius of scrollbar-thumbs can't be changed on gecko-engine based browsers like Firefox (More information here: https://caniuse.com/?search=CSS%20selector%3A%20%3A%3A-webkit-scrollbar-thumb)

## UI

**Chromium light mode**
![image](https://github.com/therungg/therun-frontend/assets/55794780/87501e9f-f944-4b4b-a6d3-8d0a13f4a9f1)

**Chromium dark mode**
![image](https://github.com/therungg/therun-frontend/assets/55794780/f45b8867-eaf4-444f-b46f-600fabb03455)

**Firefox light mode**
![image](https://github.com/therungg/therun-frontend/assets/55794780/a2aa072f-3c29-4167-bdac-80582b51fb99)

**Firefox dark mode**
![image](https://github.com/therungg/therun-frontend/assets/55794780/838712ba-85a3-4768-8731-5692652439fd)

**Safari Catalina on Chromium107 and Safari latest light mode**
![image](https://github.com/therungg/therun-frontend/assets/55794780/cd25afd6-b1cf-45d2-b7d8-cedba7464f70)

**Safari Catalina on Chromium107 and Safari latest dark mode**
![image](https://github.com/therungg/therun-frontend/assets/55794780/210a2dbe-93a8-4f0c-a0d5-066974da1942)

