### PR TITLE
Rework tournament styles

### DIFF
--- a/src/components/css/Game.module.scss
+++ b/src/components/css/Game.module.scss
@@ -47,6 +47,23 @@
 .optionalColumn {
 }
 
+.tableVertical {
+
+    tr {
+        border-bottom: 1px var(--bs-table-border-color) solid;
+        > *:first-child { padding-left: 0 }
+        > *:last-child { padding-right: 0 }
+        &:last-child { border-bottom: none}
+        &:not(:first-child) .tableVerticalHeader { margin-top: 2rem}
+    }
+}
+
+.tableVerticalHeader {
+    --bs-table-accent-bg: var(--bs-table-striped-bg);
+    text-align: center;
+    border-top: 2rem solid transparent;
+}
+
 @media screen and (max-width: 766px) {
     .statsHorizontal {
         display: none;
@@ -65,6 +82,15 @@
     .form {
         margin: 0;
         padding: 0;
+    }
+
+    .tableVertical {
+
+        tr {
+            > *:last-child:not(:only-child) {
+                text-align: right
+            }
+        }
     }
 }
 

--- a/src/components/css/LiveRun.module.scss
+++ b/src/components/css/LiveRun.module.scss
@@ -299,6 +299,7 @@
 .sortButton {
     background-color: var(--color-secondary);
     width: 100%;
+    height: 100%;
     border-color: var(--color-tertiary);
 }
 

--- a/src/components/tournament/tournament-info.tsx
+++ b/src/components/tournament/tournament-info.tsx
@@ -3,7 +3,7 @@ import { CategoryLeaderboard } from "~app/games/[game]/game.types";
 import React from "react";
 import { Col, Row, Table } from "react-bootstrap";
 import styles from "../css/Game.module.scss";
-import { PatreonBunnySvg } from "../../pages/patron";
+import { PatreonBunnySvg } from "~src/pages/patron";
 
 export interface Tournament {
     name: string;
@@ -81,42 +81,47 @@ export const TournamentInfo = ({ tournament }: { tournament: Tournament }) => {
             <Table
                 responsive
                 borderless
-                className={styles.statsHorizontal}
+                className={styles.tableVertical}
                 style={{ marginBottom: "2rem" }}
             >
-                <thead>
-                    <tr>
-                        <th>Startdate</th>
-                        <th>Enddate</th>
-                        {tournament.socials &&
-                            Object.values(tournament.socials).map((social) => {
-                                return (
-                                    <th key={social.display}>
-                                        {social.display}
-                                    </th>
-                                );
-                            })}
-                    </tr>
-                </thead>
                 <tbody>
-                    <tr>
-                        <td>{moment(tournament.startDate).format("LLL")}</td>
-                        <td>{moment(tournament.endDate).format("LLL")}</td>
-                        {tournament.socials &&
-                            Object.values(tournament.socials).map((social) => {
-                                return (
-                                    <td key={social.display}>
-                                        <a
-                                            target={"_blank"}
-                                            rel={"noreferrer"}
-                                            href={social.url}
-                                        >
-                                            {social.urlDisplay}
-                                        </a>
-                                    </td>
-                                );
-                            })}
+                    <tr className={styles.tableVerticalHeader}>
+                        <th colSpan={2}>Tournament</th>
                     </tr>
+                    <tr>
+                        <th>Starting at</th>
+                        <td>{moment(tournament.startDate).format("LLL")}</td>
+                    </tr>
+                    <tr>
+                        <th>Ending at</th>
+                        <td>{moment(tournament.endDate).format("LLL")}</td>
+                    </tr>
+                    {tournament.socials && (
+                        <tr className={styles.tableVerticalHeader}>
+                            <th colSpan={2}>Tournament socials</th>
+                        </tr>
+                    )}
+                    {tournament.socials &&
+                        Object.values(tournament.socials).map((social) => {
+                            return (
+                                <>
+                                    <tr>
+                                        <th key={social.display}>
+                                            {social.display}
+                                        </th>
+                                        <td key={social.display}>
+                                            <a
+                                                target={"_blank"}
+                                                rel={"noreferrer"}
+                                                href={social.url}
+                                            >
+                                                {social.urlDisplay}
+                                            </a>
+                                        </td>
+                                    </tr>
+                                </>
+                            );
+                        })}
                 </tbody>
             </Table>
             <Row>

--- a/src/components/tournament/tournament-runs.tsx
+++ b/src/components/tournament/tournament-runs.tsx
@@ -163,7 +163,7 @@ export const TournamentRuns = ({ data }) => {
                                 setSearch(e.target.value);
                             }}
                             value={search}
-                            id="gameSearch"
+                            id="tournamentRunSearch"
                         />
                     </div>
                 </div>


### PR DESCRIPTION
This PR introduces a few fixes and changes to the tournament pages of therun.gg

### Show tournament information on mobile devices 128df93a3def13cdf9dfb8da18180818d03fe583

Tournament information were hidden on mobile due to using the gamestats class:
#### Before
![image](https://github.com/therungg/therun-frontend/assets/55794780/eff2683a-95b0-456d-adb4-50a46eaa46dc)
#### After
![image](https://github.com/therungg/therun-frontend/assets/55794780/4da07145-8e05-4f3e-8ead-c4674da38a19)

### Allow *unlimited* socials within tournaments 128df93a3def13cdf9dfb8da18180818d03fe583

Due to the table being horizontal, many socials would *break* it by adding more horizontal headers.
New component styles ("tableVertical" and "tableVerticalHeader") have been introduced that actually add headers within rows.
This allows adding more socials as they'll just stack within this new table layout.

#### Before
![image](https://github.com/therungg/therun-frontend/assets/55794780/6f390ab5-6500-4b67-979c-bd7c6bc8421a)
#### After
![image](https://github.com/therungg/therun-frontend/assets/55794780/663d46fe-be1b-4475-85ea-13cfa73fbc9a)

### Fixed an error with a duplicate ID within the game search (tournaments) aab238332ce78341e33d6492ac06117d03077023
- the game search within the run section did share the same ID with the search in the live section which did throw an error in the frontend and is not valid HTML (duplicate IDs on a page)