### PR TITLE
(feature) Add SEO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,3 @@ Love what we do? You can support the project on [Patreon](patreon.com/therungg)!
 ## Contribute
 
 Check out our [Contribution guide](https://github.com/therungg/therun-frontend/blob/main/CONTRIBUTING.md).
-

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ speedrunners.
 
 ## Features
 
--   Live Runs tracking
--   Advanced statistics
--   Games overview
--   Splits backup
--   Twitch Extension
+- Live Runs tracking
+- Advanced statistics
+- Games overview
+- Splits backup
+- Twitch Extension
 
 and many, many more.
 
@@ -32,3 +32,4 @@ Love what we do? You can support the project on [Patreon](patreon.com/therungg)!
 ## Contribute
 
 Check out our [Contribution guide](https://github.com/therungg/therun-frontend/blob/main/CONTRIBUTING.md).
+

--- a/app/(footer)/about/page.tsx
+++ b/app/(footer)/about/page.tsx
@@ -1,10 +1,11 @@
-import { Metadata } from "next";
 import { Title } from "~src/components/title";
+import buildMetadata from "~src/utils/metadata";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "About",
-    description: "About The Run",
-};
+    description:
+        "Learn more about The Run, including what it can do and its purpose.",
+});
 
 export default function About() {
     return (

--- a/app/(footer)/blog/page.tsx
+++ b/app/(footer)/blog/page.tsx
@@ -1,10 +1,10 @@
-import { Metadata } from "next";
 import { Blog } from "./blog";
+import buildMetadata from "~src/utils/metadata";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "Blog",
-    description: "Blog for The Run",
-};
+    description: "See updates The Run posts about new and upcoming features.",
+});
 
 export default function BlogPage() {
     return <Blog />;

--- a/app/(footer)/contact/page.tsx
+++ b/app/(footer)/contact/page.tsx
@@ -1,10 +1,10 @@
-import { Metadata } from "next";
 import { Contact } from "./contact";
+import buildMetadata from "~src/utils/metadata";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "Contact",
-    description: "Here's how to contact the team",
-};
+    description: "Contact the team with your question, comments, or concerns.",
+});
 
 export default function ContactPage() {
     return <Contact />;

--- a/app/(footer)/discord/page.tsx
+++ b/app/(footer)/discord/page.tsx
@@ -1,10 +1,11 @@
-import { Metadata } from "next";
 import { redirect } from "next/navigation";
+import buildMetadata from "~src/utils/metadata";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "Discord",
-    description: "Join the Discord server",
-};
+    description:
+        "Join The Run's Discord server! Get support, give feedback and ideas, or just come hang out!",
+});
 
 export default function DiscordPage() {
     redirect(process.env.NEXT_PUBLIC_DISCORD_URL || "");

--- a/app/(footer)/faq/page.tsx
+++ b/app/(footer)/faq/page.tsx
@@ -1,10 +1,11 @@
-import { Metadata } from "next";
 import { Faq } from "./faq";
+import buildMetadata from "~src/utils/metadata";
 
-export const metadata: Metadata = {
-    title: "FAQ",
-    description: "Frequently asked questions about The Run",
-};
+export const metadata = buildMetadata({
+    title: "Frequently Asked Questions",
+    description:
+        "Get some answers to some frequently asked questions about The Run.",
+});
 
 export default function FAQPage() {
     return <Faq />;

--- a/app/(footer)/media/page.tsx
+++ b/app/(footer)/media/page.tsx
@@ -1,10 +1,11 @@
-import { Metadata } from "next";
 import { Media } from "./media";
+import buildMetadata from "~src/utils/metadata";
 
-export const metadata: Metadata = {
-    title: "Media",
-    description: "Media Kit for The Run",
-};
+export const metadata = buildMetadata({
+    title: "Media Kit",
+    description:
+        "We provide a media kit for anyone using The Run's branding in articles or their own websites. Find that here.",
+});
 
 export default function MediaPage() {
     return <Media />;

--- a/app/(footer)/privacy-policy/page.tsx
+++ b/app/(footer)/privacy-policy/page.tsx
@@ -3,7 +3,7 @@ import buildMetadata from "~src/utils/metadata";
 export const metadata = buildMetadata({
     title: "Privacy Policy",
     description:
-        "We want you to worry about your favourite games, not your data. Here's steps we take to protect your data and privacy.",
+        "We want you to worry about your favorite games, not your data. Here's steps we take to protect your data and privacy.",
 });
 
 export default function PrivacyPolicy() {

--- a/app/(footer)/privacy-policy/page.tsx
+++ b/app/(footer)/privacy-policy/page.tsx
@@ -1,9 +1,10 @@
-import { Metadata } from "next";
+import buildMetadata from "~src/utils/metadata";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "Privacy Policy",
-    description: "Here's how we handle data",
-};
+    description:
+        "We want you to worry about your favourite games, not your data. Here's steps we take to protect your data and privacy.",
+});
 
 export default function PrivacyPolicy() {
     return (

--- a/app/(footer)/roadmap/page.tsx
+++ b/app/(footer)/roadmap/page.tsx
@@ -1,9 +1,10 @@
-import { Metadata } from "next";
+import buildMetadata from "~src/utils/metadata";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "Roadmap",
-    description: "What's coming up",
-};
+    description:
+        "See a list of planned features for The Run that could be coming soon!",
+});
 
 // TODO: Link to the Github Issues or other project planning in the future
 export default function Roadmap() {

--- a/app/(footer)/terms/page.tsx
+++ b/app/(footer)/terms/page.tsx
@@ -1,9 +1,10 @@
-import { Metadata } from "next";
+import buildMetadata from "~src/utils/metadata";
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
     title: "Terms & Conditions",
-    description: "Terms & Conditions for using and accessing The Run",
-};
+    description: "Terms & Conditions for using and accessing The Run.",
+});
+
 export default function Terms() {
     return (
         <div>

--- a/app/[username]/[game]/[run]/page.tsx
+++ b/app/[username]/[game]/[run]/page.tsx
@@ -46,13 +46,22 @@ export default async function RunPage({ params, searchParams }: PageProps) {
 export async function generateMetadata({
     params,
 }: PageProps): Promise<Metadata> {
-    let imageUrl = "";
+    let imageUrl = undefined;
     const baseUrl = getBaseUrl();
     const username = params.username;
-    const response = await fetch(`${baseUrl}/api/users/${username}/global`);
+
+    if (!username) return buildMetadata();
+
+    let response: Response;
+    try {
+        response = await fetch(`${baseUrl}/api/users/${username}/global`);
+    } catch (e) {
+        return buildMetadata();
+    }
+
     const data = await response.json();
 
-    if (data) {
+    if (data?.picture) {
         imageUrl = data.picture;
     }
 
@@ -63,15 +72,17 @@ export async function generateMetadata({
     return buildMetadata({
         title: `${username}: ${gameAndCategory}`,
         description: `${username} runs ${gameAndCategory}. Check out all their attempts, personal best, and more on The Run!`,
-        images: [
-            {
-                url: imageUrl,
-                secureUrl: imageUrl,
-                alt: `Profile photo of ${username}`,
-                type: "image/png",
-                width: 300,
-                height: 300,
-            },
-        ],
+        images: imageUrl
+            ? [
+                  {
+                      url: imageUrl,
+                      secureUrl: imageUrl,
+                      alt: `Profile photo of ${username}`,
+                      type: "image/png",
+                      width: 300,
+                      height: 300,
+                  },
+              ]
+            : undefined,
     });
 }

--- a/app/[username]/[game]/[run]/page.tsx
+++ b/app/[username]/[game]/[run]/page.tsx
@@ -3,8 +3,7 @@ import { getGameGlobal } from "~src/components/game/get-game";
 import { getLiveRunForUser } from "~src/lib/live-runs";
 import RunDetail from "~app/[username]/[game]/[run]/run";
 import { Metadata } from "next";
-import { getBaseUrl } from "~src/actions/base-url.action";
-import buildMetadata from "~src/utils/metadata";
+import buildMetadata, { getUserProfilePhoto } from "~src/utils/metadata";
 import { safeDecodeURI } from "~src/utils/uri";
 
 export const revalidate = 60;
@@ -46,24 +45,9 @@ export default async function RunPage({ params, searchParams }: PageProps) {
 export async function generateMetadata({
     params,
 }: PageProps): Promise<Metadata> {
-    let imageUrl = undefined;
-    const baseUrl = getBaseUrl();
     const username = params.username;
 
     if (!username) return buildMetadata();
-
-    let response: Response;
-    try {
-        response = await fetch(`${baseUrl}/api/users/${username}/global`);
-    } catch (e) {
-        return buildMetadata();
-    }
-
-    const data = await response.json();
-
-    if (data?.picture) {
-        imageUrl = data.picture;
-    }
 
     const gameAndCategory = `${safeDecodeURI(params.game)} - ${safeDecodeURI(
         params.run
@@ -72,17 +56,6 @@ export async function generateMetadata({
     return buildMetadata({
         title: `${username}: ${gameAndCategory}`,
         description: `${username} runs ${gameAndCategory}. Check out all their attempts, personal best, and more on The Run!`,
-        images: imageUrl
-            ? [
-                  {
-                      url: imageUrl,
-                      secureUrl: imageUrl,
-                      alt: `Profile photo of ${username}`,
-                      type: "image/png",
-                      width: 300,
-                      height: 300,
-                  },
-              ]
-            : undefined,
+        images: await getUserProfilePhoto(username),
     });
 }

--- a/app/[username]/[game]/page.tsx
+++ b/app/[username]/[game]/page.tsx
@@ -42,13 +42,22 @@ export default async function CustomRunPage({ params }: PageProps) {
 export async function generateMetadata({
     params,
 }: PageProps): Promise<Metadata> {
-    let imageUrl = "";
+    let imageUrl = undefined;
     const baseUrl = getBaseUrl();
     const username = params.username;
-    const response = await fetch(`${baseUrl}/api/users/${username}/global`);
+
+    if (!username) return buildMetadata();
+
+    let response: Response;
+    try {
+        response = await fetch(`${baseUrl}/api/users/${username}/global`);
+    } catch (e) {
+        return buildMetadata();
+    }
+
     const data = await response.json();
 
-    if (data) {
+    if (data?.picture) {
         imageUrl = data.picture;
     }
 
@@ -57,15 +66,17 @@ export async function generateMetadata({
         description: `${username} runs ${safeDecodeURI(
             params.game
         )}. Check out all their attempts, personal best, and more on The Run!`,
-        images: [
-            {
-                url: imageUrl,
-                secureUrl: imageUrl,
-                alt: `Profile photo of ${username}`,
-                type: "image/png",
-                width: 300,
-                height: 300,
-            },
-        ],
+        images: imageUrl
+            ? [
+                  {
+                      url: imageUrl,
+                      secureUrl: imageUrl,
+                      alt: `Profile photo of ${username}`,
+                      type: "image/png",
+                      width: 300,
+                      height: 300,
+                  },
+              ]
+            : undefined,
     });
 }

--- a/app/[username]/[game]/page.tsx
+++ b/app/[username]/[game]/page.tsx
@@ -2,14 +2,18 @@ import { getRunByCustomUrl } from "~src/lib/get-run";
 import { getGameGlobal } from "~src/components/game/get-game";
 import { getLiveRunForUser } from "~src/lib/live-runs";
 import RunDetail from "~app/[username]/[game]/[run]/run";
+import { Metadata } from "next";
+import { getBaseUrl } from "~src/actions/base-url.action";
+import buildMetadata from "~src/utils/metadata";
+import { safeDecodeURI } from "~src/utils/uri";
 
 export const revalidate = 60;
 
-export default async function CustomRunPage({
-    params,
-}: {
+interface PageProps {
     params: { username: string; game: string };
-}) {
+}
+
+export default async function CustomRunPage({ params }: PageProps) {
     const username: string = params.username as string;
     const customUrl: string = params.game as string;
 
@@ -33,4 +37,35 @@ export default async function CustomRunPage({
             liveData={liveData}
         />
     );
+}
+
+export async function generateMetadata({
+    params,
+}: PageProps): Promise<Metadata> {
+    let imageUrl = "";
+    const baseUrl = getBaseUrl();
+    const username = params.username;
+    const response = await fetch(`${baseUrl}/api/users/${username}/global`);
+    const data = await response.json();
+
+    if (data) {
+        imageUrl = data.picture;
+    }
+
+    return buildMetadata({
+        title: username,
+        description: `${username} runs ${safeDecodeURI(
+            params.game
+        )}. Check out all their attempts, personal best, and more on The Run!`,
+        images: [
+            {
+                url: imageUrl,
+                secureUrl: imageUrl,
+                alt: `Profile photo of ${username}`,
+                type: "image/png",
+                width: 300,
+                height: 300,
+            },
+        ],
+    });
 }

--- a/app/[username]/[game]/page.tsx
+++ b/app/[username]/[game]/page.tsx
@@ -4,7 +4,6 @@ import { getLiveRunForUser } from "~src/lib/live-runs";
 import RunDetail from "~app/[username]/[game]/[run]/run";
 import { Metadata } from "next";
 import buildMetadata, { getUserProfilePhoto } from "~src/utils/metadata";
-import { safeDecodeURI } from "~src/utils/uri";
 
 export const revalidate = 60;
 
@@ -41,15 +40,20 @@ export default async function CustomRunPage({ params }: PageProps) {
 export async function generateMetadata({
     params,
 }: PageProps): Promise<Metadata> {
-    const username = params.username;
+    const username: string = params.username as string;
+    const customUrl: string = params.game as string;
 
-    if (!username) return buildMetadata();
+    if (!username || !customUrl) return buildMetadata();
+
+    const run = await getRunByCustomUrl(username, customUrl);
+    const game = run.game;
+    const runName = run.run;
+
+    const gameAndCategory = `${game} - ${runName}`;
 
     return buildMetadata({
         title: username,
-        description: `${username} runs ${safeDecodeURI(
-            params.game
-        )}. Check out all their attempts, personal best, and more on The Run!`,
+        description: `${username} runs ${gameAndCategory}. Check out all their attempts, personal best, and more on The Run!`,
         images: await getUserProfilePhoto(username),
     });
 }

--- a/app/[username]/[game]/page.tsx
+++ b/app/[username]/[game]/page.tsx
@@ -3,8 +3,7 @@ import { getGameGlobal } from "~src/components/game/get-game";
 import { getLiveRunForUser } from "~src/lib/live-runs";
 import RunDetail from "~app/[username]/[game]/[run]/run";
 import { Metadata } from "next";
-import { getBaseUrl } from "~src/actions/base-url.action";
-import buildMetadata from "~src/utils/metadata";
+import buildMetadata, { getUserProfilePhoto } from "~src/utils/metadata";
 import { safeDecodeURI } from "~src/utils/uri";
 
 export const revalidate = 60;
@@ -42,41 +41,15 @@ export default async function CustomRunPage({ params }: PageProps) {
 export async function generateMetadata({
     params,
 }: PageProps): Promise<Metadata> {
-    let imageUrl = undefined;
-    const baseUrl = getBaseUrl();
     const username = params.username;
 
     if (!username) return buildMetadata();
-
-    let response: Response;
-    try {
-        response = await fetch(`${baseUrl}/api/users/${username}/global`);
-    } catch (e) {
-        return buildMetadata();
-    }
-
-    const data = await response.json();
-
-    if (data?.picture) {
-        imageUrl = data.picture;
-    }
 
     return buildMetadata({
         title: username,
         description: `${username} runs ${safeDecodeURI(
             params.game
         )}. Check out all their attempts, personal best, and more on The Run!`,
-        images: imageUrl
-            ? [
-                  {
-                      url: imageUrl,
-                      secureUrl: imageUrl,
-                      alt: `Profile photo of ${username}`,
-                      type: "image/png",
-                      width: 300,
-                      height: 300,
-                  },
-              ]
-            : undefined,
+        images: await getUserProfilePhoto(username),
     });
 }

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -12,8 +12,7 @@ import {
 } from "~app/tournaments/tournament-list";
 import { TournamentPage } from "~app/tournaments/[tournament]/page";
 import { Metadata } from "next";
-import buildMetadata from "~src/utils/metadata";
-import { getBaseUrl } from "~src/actions/base-url.action";
+import buildMetadata, { getUserProfilePhoto } from "~src/utils/metadata";
 
 export const revalidate = 60;
 
@@ -94,39 +93,13 @@ export async function generateStaticParams() {
 export async function generateMetadata({
     params,
 }: PageProps): Promise<Metadata> {
-    let imageUrl = undefined;
-    const baseUrl = getBaseUrl();
     const username = params.username;
 
     if (!username) return buildMetadata();
 
-    let response: Response;
-    try {
-        response = await fetch(`${baseUrl}/api/users/${username}/global`);
-    } catch (e) {
-        return buildMetadata();
-    }
-
-    const data = await response.json();
-
-    if (data?.picture) {
-        imageUrl = data.picture;
-    }
-
     return buildMetadata({
         title: username,
         description: `${username} is on The Run! View their games, runs, personal bests, and more.`,
-        images: imageUrl
-            ? [
-                  {
-                      url: imageUrl,
-                      secureUrl: imageUrl,
-                      alt: `Profile photo of ${username}`,
-                      type: "image/png",
-                      width: 300,
-                      height: 300,
-                  },
-              ]
-            : undefined,
+        images: await getUserProfilePhoto(username),
     });
 }

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -94,7 +94,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({
     params,
 }: PageProps): Promise<Metadata> {
-    let imageUrl = "";
+    let imageUrl = undefined;
     const baseUrl = getBaseUrl();
     const username = params.username;
 
@@ -109,22 +109,24 @@ export async function generateMetadata({
 
     const data = await response.json();
 
-    if (data) {
+    if (data?.picture) {
         imageUrl = data.picture;
     }
 
     return buildMetadata({
         title: username,
         description: `${username} is on The Run! View their games, runs, personal bests, and more.`,
-        images: [
-            {
-                url: imageUrl,
-                secureUrl: imageUrl,
-                alt: `Profile photo of ${username}`,
-                type: "image/png",
-                width: 300,
-                height: 300,
-            },
-        ],
+        images: imageUrl
+            ? [
+                  {
+                      url: imageUrl,
+                      secureUrl: imageUrl,
+                      alt: `Profile photo of ${username}`,
+                      type: "image/png",
+                      width: 300,
+                      height: 300,
+                  },
+              ]
+            : undefined,
     });
 }

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -97,7 +97,16 @@ export async function generateMetadata({
     let imageUrl = "";
     const baseUrl = getBaseUrl();
     const username = params.username;
-    const response = await fetch(`${baseUrl}/api/users/${username}/global`);
+
+    if (!username) return buildMetadata();
+
+    let response: Response;
+    try {
+        response = await fetch(`${baseUrl}/api/users/${username}/global`);
+    } catch (e) {
+        return buildMetadata();
+    }
+
     const data = await response.json();
 
     if (data) {

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -11,16 +11,18 @@ import {
     getTournamentNameFromSlug,
 } from "~app/tournaments/tournament-list";
 import { TournamentPage } from "~app/tournaments/[tournament]/page";
+import { Metadata } from "next";
+import buildMetadata from "~src/utils/metadata";
+import { getBaseUrl } from "~src/actions/base-url.action";
 
 export const revalidate = 60;
 
-export default async function Page({
-    params,
-    searchParams,
-}: {
+interface PageProps {
     params: { username: string };
     searchParams: { [_: string]: string };
-}) {
+}
+
+export default async function Page({ params, searchParams }: PageProps) {
     if (!params || !params.username) throw new Error("Username not found");
 
     const username: string = params.username as string;
@@ -86,5 +88,34 @@ export default async function Page({
 export async function generateStaticParams() {
     return getAllTournamentSlugs().map((tournament) => {
         return { username: tournament };
+    });
+}
+
+export async function generateMetadata({
+    params,
+}: PageProps): Promise<Metadata> {
+    let imageUrl = "";
+    const baseUrl = getBaseUrl();
+    const username = params.username;
+    const response = await fetch(`${baseUrl}/api/users/${username}/global`);
+    const data = await response.json();
+
+    if (data) {
+        imageUrl = data.picture;
+    }
+
+    return buildMetadata({
+        title: username,
+        description: `${username} is on The Run! View their games, runs, personal bests, and more.`,
+        images: [
+            {
+                url: imageUrl,
+                secureUrl: imageUrl,
+                alt: `Profile photo of ${username}`,
+                type: "image/png",
+                width: 300,
+                height: 300,
+            },
+        ],
     });
 }

--- a/app/change-appearance/page.tsx
+++ b/app/change-appearance/page.tsx
@@ -4,6 +4,7 @@ import { getUserPatreonData } from "~src/actions/user-patreon-data.action";
 import { LoginWithPatreon } from "~app/change-appearance/login-with-patreon";
 import { getBaseUrl } from "~src/actions/base-url.action";
 import PatreonSection from "~app/change-appearance/patreon-section";
+import buildMetadata from "~src/utils/metadata";
 
 export const revalidate = 0;
 
@@ -29,3 +30,10 @@ export default async function ChangeAppearance({
         </div>
     );
 }
+
+export const metadata = buildMetadata({
+    title: "Change Appearance",
+    description:
+        "Change your appearance on The Run. Thanks for being a supporter!",
+    index: false,
+});

--- a/app/games/[game]/page.tsx
+++ b/app/games/[game]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from "next";
 import { getBaseUrl } from "~src/actions/base-url.action";
 import { safeDecodeURI, safeEncodeURI } from "~src/utils/uri";
 import { Game } from "./game";
-import buildMetadata from "~src/utils/metadata";
+import buildMetadata, { getGameImage } from "~src/utils/metadata";
 
 interface PageProps {
     params: { game: string };
@@ -51,36 +51,10 @@ export async function generateMetadata({
     if (!params.game) return buildMetadata();
 
     const game = safeDecodeURI(params.game);
-    let imageUrl = undefined;
-    const baseUrl = getBaseUrl();
-
-    let response: Response;
-    try {
-        response = await fetch(`${baseUrl}/api/games/${params.game}/global`);
-    } catch (e) {
-        return buildMetadata();
-    }
-
-    const data = await response.json();
-
-    if (data?.image) {
-        imageUrl = data.image;
-    }
 
     return buildMetadata({
-        title: game,
+        title: `Statistics for ${game}`,
         description: `View statistics for ${game}, including categories, top runners, total run time, and more!`,
-        images: imageUrl
-            ? [
-                  {
-                      url: imageUrl,
-                      secureUrl: imageUrl,
-                      alt: `${game} cover`,
-                      type: "image/png",
-                      width: 800,
-                      height: 600,
-                  },
-              ]
-            : undefined,
+        images: await getGameImage(game),
     });
 }

--- a/app/games/[game]/page.tsx
+++ b/app/games/[game]/page.tsx
@@ -1,7 +1,8 @@
 import { Metadata } from "next";
 import { getBaseUrl } from "~src/actions/base-url.action";
-import { safeEncodeURI } from "~src/utils/uri";
+import { safeDecodeURI, safeEncodeURI } from "~src/utils/uri";
 import { Game } from "./game";
+import buildMetadata from "~src/utils/metadata";
 
 interface PageProps {
     params: { game: string };
@@ -10,10 +11,30 @@ interface PageProps {
 export async function generateMetadata({
     params,
 }: PageProps): Promise<Metadata> {
-    return {
-        title: params.game,
-        description: `The Run game overview for ${params.game}`,
-    };
+    const game = safeDecodeURI(params.game);
+    let imageUrl = "";
+    const baseUrl = getBaseUrl();
+    const response = await fetch(`${baseUrl}/api/games/${params.game}/global`);
+    const data = await response.json();
+
+    if (data) {
+        imageUrl = data.image;
+    }
+
+    return buildMetadata({
+        title: game,
+        description: `View statistics for ${game}, including categories, top runners, total run time, and more!`,
+        images: [
+            {
+                url: imageUrl,
+                secureUrl: imageUrl,
+                alt: `${game} cover`,
+                type: "image/png",
+                width: 800,
+                height: 600,
+            },
+        ],
+    });
 }
 
 export default async function GamePage({ params }: PageProps) {

--- a/app/games/[game]/page.tsx
+++ b/app/games/[game]/page.tsx
@@ -8,35 +8,6 @@ interface PageProps {
     params: { game: string };
 }
 
-export async function generateMetadata({
-    params,
-}: PageProps): Promise<Metadata> {
-    const game = safeDecodeURI(params.game);
-    let imageUrl = "";
-    const baseUrl = getBaseUrl();
-    const response = await fetch(`${baseUrl}/api/games/${params.game}/global`);
-    const data = await response.json();
-
-    if (data) {
-        imageUrl = data.image;
-    }
-
-    return buildMetadata({
-        title: game,
-        description: `View statistics for ${game}, including categories, top runners, total run time, and more!`,
-        images: [
-            {
-                url: imageUrl,
-                secureUrl: imageUrl,
-                alt: `${game} cover`,
-                type: "image/png",
-                width: 800,
-                height: 600,
-            },
-        ],
-    });
-}
-
 export default async function GamePage({ params }: PageProps) {
     const { game: gameName } = params;
     const baseUrl = getBaseUrl();
@@ -72,4 +43,44 @@ export default async function GamePage({ params }: PageProps) {
         );
     }
     return <Game data={data} />;
+}
+
+export async function generateMetadata({
+    params,
+}: PageProps): Promise<Metadata> {
+    if (!params.game) return buildMetadata();
+
+    const game = safeDecodeURI(params.game);
+    let imageUrl = undefined;
+    const baseUrl = getBaseUrl();
+
+    let response: Response;
+    try {
+        response = await fetch(`${baseUrl}/api/games/${params.game}/global`);
+    } catch (e) {
+        return buildMetadata();
+    }
+
+    const data = await response.json();
+
+    if (data?.image) {
+        imageUrl = data.image;
+    }
+
+    return buildMetadata({
+        title: game,
+        description: `View statistics for ${game}, including categories, top runners, total run time, and more!`,
+        images: imageUrl
+            ? [
+                  {
+                      url: imageUrl,
+                      secureUrl: imageUrl,
+                      alt: `${game} cover`,
+                      type: "image/png",
+                      width: 800,
+                      height: 600,
+                  },
+              ]
+            : undefined,
+    });
 }

--- a/app/games/page.tsx
+++ b/app/games/page.tsx
@@ -1,13 +1,14 @@
 import { Metadata } from "next";
 import { AllGames } from "./all-games";
 import { getGamesPage } from "~src/components/game/get-tabulated-game-stats";
+import buildMetadata from "~src/utils/metadata";
 
 export const revalidate = 60 * 60 * 6;
 
-export const metadata: Metadata = {
+export const metadata: Metadata = buildMetadata({
     title: "Game overview",
     description: "All games overview",
-};
+});
 
 export default async function AllGamesPage() {
     const allGames = await getGamesPage();

--- a/app/how-it-works/page.tsx
+++ b/app/how-it-works/page.tsx
@@ -1,5 +1,6 @@
 import { getSession } from "~src/actions/session.action";
 import HowItWorksPanels from "~app/how-it-works/how-it-works-panels";
+import buildMetadata from "~src/utils/metadata";
 
 export const revalidate = 0;
 
@@ -17,3 +18,9 @@ export default async function howItWorks() {
         </>
     );
 }
+
+export const metadata = buildMetadata({
+    title: "How It Works",
+    description:
+        "Learn how The Run works and how it can be useful to you, whether you are a runner yourself or just a fan of speedrunning!",
+});

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Metadata } from "next";
 import "nprogress/nprogress.css";
 import "./material-symbols-outline.css";
 import "../src/styles/_import.scss";
@@ -9,54 +8,9 @@ import { Content } from "./content";
 import { Providers } from "./providers";
 import { Scripts } from "./scripts";
 import { getSession } from "~src/actions/session.action";
+import buildMetadata from "~src/utils/metadata";
 
-const metaTitle = "The Run - Speedrun Statistics";
-const metaDescription =
-    "The Run - a free tool for speedrun statistics. Explore leaderboards, check out live runs, and easily manage your own speedrun data!";
-const metaImageUrl = "/therun-no-url-with-black-background.png";
-
-export const metadata: Metadata = {
-    metadataBase: new URL("https://therun.gg"),
-    title: {
-        default: metaTitle,
-        template: "The Run - %s",
-    },
-    description: metaDescription,
-    keywords: ["TheRun", "Speedrun", "Statistics"],
-    themeColor: "#007c00",
-    manifest: "/site.webmanifest",
-    referrer: "strict-origin-when-cross-origin",
-    other: {
-        "msapplication-TileColor": "#007c00",
-    },
-    openGraph: {
-        title: metaTitle,
-        description: metaDescription,
-        url: "/",
-        siteName: "The Run",
-        locale: "en_US",
-        type: "website",
-        images: [
-            {
-                url: metaImageUrl,
-                secureUrl: metaImageUrl,
-                alt: "The Run logo",
-                type: "image/png",
-                width: 800,
-                height: 600,
-            },
-        ],
-    },
-    twitter: {
-        title: metaTitle,
-        description: metaDescription,
-        siteId: "1482414005138477061",
-        creator: "@therungg",
-        creatorId: "1482414005138477061",
-        card: "summary_large_image",
-        images: [metaImageUrl],
-    },
-};
+export const metadata = buildMetadata();
 
 export default async function RootLayout({
     // Layouts must accept a children prop.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,16 +10,51 @@ import { Providers } from "./providers";
 import { Scripts } from "./scripts";
 import { getSession } from "~src/actions/session.action";
 
+const metaTitle = "The Run - Speedrun Statistics";
+const metaDescription =
+    "The Run - a free tool for speedrun statistics. Explore leaderboards, check out live runs, and easily manage your own speedrun data!";
+const metaImageUrl = "/therun-no-url-with-black-background.png";
+
 export const metadata: Metadata = {
+    metadataBase: new URL("https://therun.gg"),
     title: {
-        default: "The Run - Speedrun Statistics",
+        default: metaTitle,
         template: "The Run - %s",
     },
-    description: "The Run - a free tool for speedrun statistics",
-    themeColor: "#ffffff",
+    description: metaDescription,
+    keywords: ["TheRun", "Speedrun", "Statistics"],
+    themeColor: "#007c00",
     manifest: "/site.webmanifest",
+    referrer: "strict-origin-when-cross-origin",
     other: {
-        "msapplication-TileColor": "#ffffff",
+        "msapplication-TileColor": "#007c00",
+    },
+    openGraph: {
+        title: metaTitle,
+        description: metaDescription,
+        url: "/",
+        siteName: "The Run",
+        locale: "en_US",
+        type: "website",
+        images: [
+            {
+                url: metaImageUrl,
+                secureUrl: metaImageUrl,
+                alt: "The Run logo",
+                type: "image/png",
+                width: 800,
+                height: 600,
+            },
+        ],
+    },
+    twitter: {
+        title: metaTitle,
+        description: metaDescription,
+        siteId: "1482414005138477061",
+        creator: "@therungg",
+        creatorId: "1482414005138477061",
+        card: "summary_large_image",
+        images: [metaImageUrl],
     },
 };
 

--- a/app/live/[username]/page.tsx
+++ b/app/live/[username]/page.tsx
@@ -2,6 +2,9 @@ import { getAllLiveRuns } from "~src/lib/live-runs";
 import { LiveRun } from "~app/live/live.types";
 import { liveRunArrayToMap } from "~app/live/utilities";
 import { Live } from "~app/live/live";
+import { Metadata } from "next";
+import { getBaseUrl } from "~src/actions/base-url.action";
+import buildMetadata from "~src/utils/metadata";
 
 export const revalidate = 0;
 
@@ -14,4 +17,34 @@ export default async function LiveUser({ params }: PageProps) {
     const liveDataMap = liveRunArrayToMap(liveData);
 
     return <Live liveDataMap={liveDataMap} username={params.username} />;
+}
+
+export async function generateMetadata({
+    params,
+}: PageProps): Promise<Metadata> {
+    let imageUrl = "";
+    const baseUrl = getBaseUrl();
+    const username = params.username;
+    const response = await fetch(`${baseUrl}/api/users/${username}/global`);
+    const data = await response.json();
+
+    if (data) {
+        imageUrl = data.picture;
+    }
+
+    return buildMetadata({
+        title: `Watch ${username} Live`,
+        description: `${username} is live on The Run! Watch their run in real time and see data about their run, including current pace.`,
+        images: [
+            {
+                url: imageUrl,
+                secureUrl: imageUrl,
+                alt: `Profile photo of ${username}`,
+                type: "image/png",
+                width: 300,
+                height: 300,
+            },
+        ],
+        index: false,
+    });
 }

--- a/app/live/[username]/page.tsx
+++ b/app/live/[username]/page.tsx
@@ -22,29 +22,40 @@ export default async function LiveUser({ params }: PageProps) {
 export async function generateMetadata({
     params,
 }: PageProps): Promise<Metadata> {
-    let imageUrl = "";
+    let imageUrl = undefined;
     const baseUrl = getBaseUrl();
     const username = params.username;
-    const response = await fetch(`${baseUrl}/api/users/${username}/global`);
+
+    if (!username) return buildMetadata();
+
+    let response: Response;
+    try {
+        response = await fetch(`${baseUrl}/api/users/${username}/global`);
+    } catch (e) {
+        return buildMetadata();
+    }
+
     const data = await response.json();
 
-    if (data) {
+    if (data?.picture) {
         imageUrl = data.picture;
     }
 
     return buildMetadata({
         title: `Watch ${username} Live`,
         description: `${username} is live on The Run! Watch their run in real time and see data about their run, including current pace.`,
-        images: [
-            {
-                url: imageUrl,
-                secureUrl: imageUrl,
-                alt: `Profile photo of ${username}`,
-                type: "image/png",
-                width: 300,
-                height: 300,
-            },
-        ],
+        images: imageUrl
+            ? [
+                  {
+                      url: imageUrl,
+                      secureUrl: imageUrl,
+                      alt: `Profile photo of ${username}`,
+                      type: "image/png",
+                      width: 300,
+                      height: 300,
+                  },
+              ]
+            : undefined,
         index: false,
     });
 }

--- a/app/live/page.tsx
+++ b/app/live/page.tsx
@@ -16,5 +16,5 @@ export default async function LivePage() {
 export const metadata = buildMetadata({
     title: "Watch Live Runs",
     description:
-        "Watch streams of runners who are currently live and attempting a run, and discover new runners for your favourite games!",
+        "Watch streams of runners who are currently live and attempting a run, and discover new runners for your favorite games!",
 });

--- a/app/live/page.tsx
+++ b/app/live/page.tsx
@@ -2,6 +2,7 @@ import { getAllLiveRuns } from "~src/lib/live-runs";
 import { Live } from "~app/live/live";
 import { liveRunArrayToMap } from "~app/live/utilities";
 import { LiveRun } from "~app/live/live.types";
+import buildMetadata from "~src/utils/metadata";
 
 export const revalidate = 0;
 
@@ -11,3 +12,9 @@ export default async function LivePage() {
 
     return <Live liveDataMap={liveDataMap} />;
 }
+
+export const metadata = buildMetadata({
+    title: "Watch Live Runs",
+    description:
+        "Watch streams of runners who are currently live and attempting a run, and discover new runners for your favourite games!",
+});

--- a/app/patreon/page.tsx
+++ b/app/patreon/page.tsx
@@ -1,7 +1,14 @@
 import React from "react";
+import buildMetadata from "~src/utils/metadata";
 import PatronPage from "~app/patron/page";
 
 export const revalidate = 0;
 export default async function PatreonPage() {
     return <PatronPage />;
 }
+
+export const metadata = buildMetadata({
+    title: "Support",
+    description:
+        "Like The Run and find it useful? Consider supporting it today by becoming a Patron and get some visual perks for doing so!",
+});

--- a/app/patron/page.tsx
+++ b/app/patron/page.tsx
@@ -1,9 +1,16 @@
 import React from "react";
 import { PatreonInfo } from "~app/patron/patreon-info";
 import { getSession } from "~src/actions/session.action";
+import buildMetadata from "~src/utils/metadata";
 
 export const revalidate = 0;
 export default async function PatronPage() {
     const session = await getSession();
     return <PatreonInfo session={session} />;
 }
+
+export const metadata = buildMetadata({
+    title: "Support",
+    description:
+        "Like The Run and find it useful? Consider supporting it today by becoming a Patron and get some visual perks for doing so!",
+});

--- a/app/sitemap.tsx
+++ b/app/sitemap.tsx
@@ -1,0 +1,40 @@
+import { globbySync } from "globby";
+import { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+    const ignoredRoutes: string[] = [
+        "/games/[game]/",
+        "/live/[username]/",
+        "/tournaments/[tournament]/",
+        "/[username]/[game]/",
+        "/blog/[post]/",
+        "/[username]/[game]/[run]/",
+        "/[username]/",
+        "/upload-key/",
+        "/change-appearance/",
+    ];
+
+    const pages = globbySync(["app/**/page.tsx", "!app/api"]);
+
+    const cleanedPaths = pages.map((route) => {
+        const path = route
+            .replace("app", "")
+            .replace(".tsx", "")
+            .replace("page", "")
+            .replace("/(footer)", "");
+        const page = route === "/" ? "" : path;
+
+        return page;
+    });
+
+    const routes = cleanedPaths
+        .filter((path) => !ignoredRoutes.includes(path))
+        .map((route) => {
+            return {
+                url: `https://therun.gg${route}`,
+                lastModified: new Date().toISOString(),
+            };
+        });
+
+    return routes;
+}

--- a/app/tournaments/[tournament]/page.tsx
+++ b/app/tournaments/[tournament]/page.tsx
@@ -6,15 +6,17 @@ import { isLiveDataEligibleForTournament } from "./is-live-data-eligible-for-tou
 import { GenericTournament } from "~app/tournaments/[tournament]/tournament";
 import { getSession } from "~src/actions/session.action";
 import { liveRunArrayToMap } from "~app/tournaments/[tournament]/live-run-array-to-map.component";
+import buildMetadata from "~src/utils/metadata";
+import { safeDecodeURI } from "~src/utils/uri";
 
 export const revalidate = 30;
-export default async function Page({
-    params,
-    searchParams,
-}: {
+
+interface PageProps {
     params: { tournament: string };
     searchParams: { [_: string]: string };
-}) {
+}
+
+export default async function Page({ params, searchParams }: PageProps) {
     return TournamentPage({ params, searchParams });
 }
 
@@ -69,3 +71,15 @@ export const TournamentPage = async ({
         />
     );
 };
+
+export async function generateMetadata({ params }: PageProps) {
+    const name = safeDecodeURI(params.tournament);
+    const endString = name.toLowerCase().includes("tournament")
+        ? `the ${name}`
+        : `the ${name} tournament`;
+
+    return buildMetadata({
+        title: name,
+        description: `See leaderboards and other statistics for ${endString}!`,
+    });
+}

--- a/app/tournaments/page.tsx
+++ b/app/tournaments/page.tsx
@@ -1,6 +1,7 @@
 import { Tournament } from "~src/components/tournament/tournament-info";
 import { getTournaments } from "~src/components/tournament/getTournaments";
 import { AllTournaments } from "~app/tournaments/all-tournaments";
+import buildMetadata from "~src/utils/metadata";
 
 export const revalidate = 0;
 export default async function TournamentsPage() {
@@ -26,3 +27,9 @@ export default async function TournamentsPage() {
         />
     );
 }
+
+export const metadata = buildMetadata({
+    title: "Tournaments",
+    description:
+        "Itching for some tournament action? Browse a selection of tournaments whose participants use The Run for an unprecedented look at tournament statistics!",
+});

--- a/app/upload-key/page.tsx
+++ b/app/upload-key/page.tsx
@@ -3,6 +3,7 @@ import uploadKeyStyles from "../../src/components/css/UploadKey.module.scss";
 import { getSession } from "~src/actions/session.action";
 import { CopyUploadKey } from "./copy-upload-key.component";
 import { getBaseUrl } from "~src/actions/base-url.action";
+import buildMetadata from "~src/utils/metadata";
 
 export const revalidate = 0;
 
@@ -140,3 +141,11 @@ export default async function UploadKey() {
         </div>
     );
 }
+
+export const metadata = buildMetadata({
+    title: "Your Upload Key",
+    description:
+        "Get your upload key to use in The Run's LiveSplit component from here.",
+    index: false,
+    follow: false,
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cookies-next": "^2.0.3",
         "country-flag-icons": "^1.5.5",
         "d3": "^7.8.4",
+        "globby": "^13.2.2",
         "jquery": "^3.6.0",
         "js-levenshtein": "^1.1.6",
         "luxon": "^3.0.4",
@@ -769,7 +770,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -782,7 +782,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -791,7 +790,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -1478,6 +1476,35 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.59.5",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.5.tgz",
@@ -1671,7 +1698,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -1899,7 +1926,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -1948,7 +1975,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -2095,7 +2121,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -2122,7 +2148,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -2868,7 +2894,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -3246,37 +3271,6 @@
       "peerDependencies": {
         "eslint": "*",
         "eslint-plugin-import": "*"
-      }
-    },
-    "node_modules/eslint-import-resolver-typescript/node_modules/globby": {
-      "version": "13.1.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
-      "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
-      "dev": true,
-      "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.11",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-import-resolver-typescript/node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -3776,10 +3770,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
-      "dev": true,
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -3795,7 +3788,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -3819,7 +3811,6 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
       "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
-      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -3851,7 +3842,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -4079,20 +4069,18 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
       "dependencies": {
-        "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
+        "fast-glob": "^3.3.0",
+        "ignore": "^5.2.4",
         "merge2": "^1.4.1",
-        "slash": "^3.0.0"
+        "slash": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4274,7 +4262,6 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -4283,7 +4270,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
       "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -4415,7 +4402,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -4496,7 +4483,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4517,7 +4503,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -4568,7 +4553,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -5311,7 +5295,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -5320,7 +5303,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -5556,7 +5538,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6107,7 +6089,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6465,7 +6446,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -6566,7 +6547,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -6706,7 +6686,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6762,7 +6741,7 @@
       "version": "1.62.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
       "integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -6855,12 +6834,14 @@
       "dev": true
     },
     "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/slice-ansi": {
@@ -7283,7 +7264,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "cookies-next": "^2.0.3",
     "country-flag-icons": "^1.5.5",
     "d3": "^7.8.4",
+    "globby": "^13.2.2",
     "jquery": "^3.6.0",
     "js-levenshtein": "^1.1.6",
     "luxon": "^3.0.4",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,10 @@
+# *
 User-agent: *
 Allow: /
+Disallow: /api/*
+
+# Host
+Host: https://therun.gg
+
+# Sitemaps
+Sitemap: https://therun.gg/sitemap.xml

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -10,7 +10,8 @@ declare type OpenGraphImage = {
 };
 
 export interface MetadataProps {
-    title: string;
+    title?: string;
+    absoluteTitle?: string;
     description: string;
     keywords?: string[];
     type?: OpenGraphType;
@@ -20,41 +21,58 @@ export interface MetadataProps {
 }
 
 /**
- * Builds a Metadata object for child pages. This method is not suitable for the parent layout.tsx file.
+ * Builds a Metadata object for pages.
  * @param props
  * @returns
  */
-export default function buildMetadata(props: MetadataProps): Metadata {
+export default function buildMetadata(props?: MetadataProps): Metadata {
     const defaultImageUrl = "/therun-no-url-with-black-background.png";
+    const title =
+        props?.absoluteTitle ||
+        `The Run - ${props?.title || "Speedrun Statistics"}`;
+    const description =
+        props?.description ||
+        "The Run - a free tool for speedrun statistics. Explore leaderboards, check out live runs, and easily manage your own speedrun data!";
 
     // Resolving Twitter images
     let twitterImages: string[] = [];
 
-    props.images?.map((image: OpenGraphImage) => {
+    props?.images?.map((image: OpenGraphImage) => {
         if (image.url) twitterImages.push(image.url.toString());
     });
 
     if (twitterImages.length === 0) twitterImages = [defaultImageUrl];
 
     return {
-        title: props.title,
-        description: props.description,
-        keywords: props.keywords || ["TheRun", "Speedrun", "Statistics"],
+        metadataBase: new URL("https://therun.gg"),
+        title,
+        description,
+        keywords: props?.keywords || ["TheRun", "Speedrun", "Statistics"],
+        themeColor: "#007c00",
+        manifest: "/site.webmanifest",
+        referrer: "strict-origin-when-cross-origin",
+        other: {
+            "msapplication-TileColor": "#007c00",
+        },
         openGraph: {
-            title: `The Run - ${props.title}`,
-            description: props.description,
-            type: props.type || "website",
-            images: props.images || {
+            title,
+            description,
+            url: "/",
+            siteName: "The Run",
+            locale: "en_US",
+            type: props?.type || "website",
+            images: props?.images || {
                 url: defaultImageUrl,
                 secureUrl: defaultImageUrl,
+                alt: "The Run logo",
                 type: "image/png",
                 width: 800,
                 height: 600,
             },
         },
         twitter: {
-            title: `The Run - ${props.title}`,
-            description: props.description,
+            title,
+            description,
             siteId: "1482414005138477061",
             creator: "@therungg",
             creatorId: "1482414005138477061",
@@ -62,11 +80,11 @@ export default function buildMetadata(props: MetadataProps): Metadata {
             images: twitterImages,
         },
         robots: {
-            index: props.index || true,
-            follow: props.index || true,
+            index: props?.index || true,
+            follow: props?.index || true,
             googleBot: {
-                index: props.index || true,
-                follow: props.index || true,
+                index: props?.index || true,
+                follow: props?.index || true,
             },
         },
     };

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,0 +1,73 @@
+import { Metadata } from "next";
+import { OpenGraphType } from "next/dist/lib/metadata/types/opengraph-types";
+declare type OpenGraphImage = {
+    url: string | URL;
+    secureUrl?: string | URL;
+    alt?: string;
+    type?: string;
+    width?: string | number;
+    height?: string | number;
+};
+
+export interface MetadataProps {
+    title: string;
+    description: string;
+    keywords?: string[];
+    type?: OpenGraphType;
+    images?: OpenGraphImage[];
+    index?: boolean;
+    follow?: boolean;
+}
+
+/**
+ * Builds a Metadata object for child pages. This method is not suitable for the parent layout.tsx file.
+ * @param props
+ * @returns
+ */
+export default function buildMetadata(props: MetadataProps): Metadata {
+    const defaultImageUrl = "/therun-no-url-with-black-background.png";
+
+    // Resolving Twitter images
+    let twitterImages: string[] = [];
+
+    props.images?.map((image: OpenGraphImage) => {
+        if (image.url) twitterImages.push(image.url.toString());
+    });
+
+    if (twitterImages.length === 0) twitterImages = [defaultImageUrl];
+
+    return {
+        title: props.title,
+        description: props.description,
+        keywords: props.keywords || ["TheRun", "Speedrun", "Statistics"],
+        openGraph: {
+            title: `The Run - ${props.title}`,
+            description: props.description,
+            type: props.type || "website",
+            images: props.images || {
+                url: defaultImageUrl,
+                secureUrl: defaultImageUrl,
+                type: "image/png",
+                width: 800,
+                height: 600,
+            },
+        },
+        twitter: {
+            title: `The Run - ${props.title}`,
+            description: props.description,
+            siteId: "1482414005138477061",
+            creator: "@therungg",
+            creatorId: "1482414005138477061",
+            card: "summary_large_image",
+            images: twitterImages,
+        },
+        robots: {
+            index: props.index || true,
+            follow: props.index || true,
+            googleBot: {
+                index: props.index || true,
+                follow: props.index || true,
+            },
+        },
+    };
+}

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,5 +1,7 @@
 import { Metadata } from "next";
 import { OpenGraphType } from "next/dist/lib/metadata/types/opengraph-types";
+import { getBaseUrl } from "~src/actions/base-url.action";
+
 declare type OpenGraphImage = {
     url: string | URL;
     secureUrl?: string | URL;
@@ -88,4 +90,52 @@ export default function buildMetadata(props?: MetadataProps): Metadata {
             },
         },
     };
+}
+
+export async function getUserProfilePhoto(
+    username: string
+): Promise<OpenGraphImage[] | undefined> {
+    let response: Response;
+    try {
+        response = await fetch(`${getBaseUrl()}/api/users/${username}/global`);
+    } catch (e) {
+        return undefined;
+    }
+
+    const data = await response.json();
+
+    if (!data?.picture) return undefined;
+
+    return [
+        {
+            url: data.picture,
+            secureUrl: data.picture,
+            alt: `Profile photo of ${username}`,
+            type: "image/png",
+        },
+    ];
+}
+
+export async function getGameImage(
+    game: string
+): Promise<OpenGraphImage[] | undefined> {
+    let response: Response;
+    try {
+        response = await fetch(`${getBaseUrl()}/api/games/${game}/global`);
+    } catch (e) {
+        return undefined;
+    }
+
+    const data = await response.json();
+
+    if (!data?.image) return undefined;
+
+    return [
+        {
+            url: data.image,
+            secureUrl: data.image,
+            alt: `${game} cover`,
+            type: "image/png",
+        },
+    ];
 }


### PR DESCRIPTION
Adds SEO support across The Run.

- A wrapper function, `buildMetadata`, was created. This prevents duplicating things such as OpenGraph properties (these don't get merged as of now when the Metadata gets merged with parent / child pages, hence why it exists.
- Updated the mobile theme to use The Run's green
- A sitemap is now generated on-demand using Next's built-in sitemap feature. A package called `globby` was added to assist in pattern matching pages to be added to the sitemap. Dynamic pages are not currently included - it isn't necessary right now and may never be, but it could be a discussion for another time.
- Every page (with the exception of moist-setup, marathons, and blog posts) now have unique titles and descriptions.

Resolves #92 