### PR TITLE
Fix tournament layout + seo on tournament pages

### DIFF
--- a/app/tournaments/all-tournaments.tsx
+++ b/app/tournaments/all-tournaments.tsx
@@ -13,15 +13,17 @@ export function AllTournaments({
 }: AllTournamentsProps) {
     return (
         <div>
-            <h1>Ongoing tournaments</h1>
+            <h1>Tournaments</h1>
+
+            <h2>Ongoing tournaments</h2>
 
             <ListTournaments tournaments={ongoingTournaments} />
 
-            <h1>Upcoming tournaments</h1>
+            <h2>Upcoming tournaments</h2>
 
             <ListTournaments tournaments={upcomingTournaments} />
 
-            <h1>Finished tournaments</h1>
+            <h2>Finished tournaments</h2>
 
             <ListTournaments tournaments={finishedTournaments} />
         </div>
@@ -34,7 +36,7 @@ export const ListTournaments = ({
     tournaments: Tournament[];
 }) => {
     return (
-        <Row>
+        <Row className={"g-3 mb-5"}>
             {tournaments.map((tournament: Tournament) => {
                 const startDate = new Date(tournament.startDate);
                 const endDate = new Date(tournament.endDate);
@@ -46,7 +48,7 @@ export const ListTournaments = ({
                 return (
                     <Col sm={12} lg={6} key={tournament.name}>
                         {tournament.logoUrl && (
-                            <div className="float-start d-flex d-none d-sm-block align-items-center me-2 ms-2">
+                            <div className="float-start d-flex d-none d-sm-block align-items-center me-2">
                                 <a
                                     href={`/tournaments/${safeEncodeURI(
                                         tournament.name


### PR DESCRIPTION
This PR introduces:
- layout changes on the past tournaments ran as seen in the following pictures
- SEO changes where having multiple h1 not being w3c compliant

**Before**
![image](https://github.com/therungg/therun-frontend/assets/55794780/9906a562-85a1-4a9e-8426-4c7e49c314ea)

**After**
![image](https://github.com/therungg/therun-frontend/assets/55794780/9fdbad9c-bc64-44d3-aeec-3b4f38feb028)
