### PR TITLE
Use clearfix on user game overview

### DIFF
--- a/src/components/run/user-detail/user-overview.tsx
+++ b/src/components/run/user-detail/user-overview.tsx
@@ -93,6 +93,7 @@ export const UserOverview = ({
                 return (
                     <div
                         key={n}
+                        className="clearfix"
                         style={{
                             marginLeft:
                                 sameGame && globalData && images.length > 0


### PR DESCRIPTION
Problem:
- Layouting
- It looks like the image sizes for amok runner and call of duty are off, even though igdb should deliver them in the expected format.

Solution:
- when floating items within a container, a clearfix should be used to prevent layout shifting like this:
![image](https://github.com/therungg/therun-frontend/assets/55794780/b168e02a-04b2-4556-a6f7-fc854c4731ff)

