### PR TITLE
Disable infinite animations (Chromium v121 issue)

### DIFF
--- a/src/components/css/DarkModeSlider.module.scss
+++ b/src/components/css/DarkModeSlider.module.scss
@@ -80,7 +80,8 @@
     height: 2.5px;
     background-color: #ffffff;
     border-radius: 9999px;
-    animation: twinkle 0.8s infinite -0.6s;
+    //animation: twinkle 0.8s infinite -0.6s;
+    opacity: .3;
 
     &::before,
     &::after {
@@ -97,13 +98,14 @@
       top: -10px;
       left: 5px;
       opacity: 1;
-      animation: twinkle 0.6s infinite;
+      //animation: twinkle 0.6s infinite;
     }
 
     &::after {
       top: -3.5px;
       left: 15px;
-      animation: twinkle 0.6s infinite -0.2s;
+      //animation: twinkle 0.6s infinite -0.2s;
+      opacity: .4;
     }
   }
 
@@ -126,10 +128,11 @@
     .switch__decoration {
       top: 50%;
       transform: translate(0%, -50%);
-      animation: cloud 8s linear infinite;
+      //animation: cloud 8s linear infinite;
 
       width: 10px;
       height: 10px;
+      opacity: 1;
 
       &::before {
         width: 5px;
@@ -137,7 +140,8 @@
         top: auto;
         bottom: 0;
         left: -4px;
-        animation: none;
+        //animation: none;
+        opacity: 1;
       }
 
       &::after {
@@ -146,7 +150,8 @@
         top: auto;
         bottom: 0;
         left: 8px;
-        animation: none;
+        //animation: none;
+        opacity: 1;
       }
 
       &,
@@ -162,7 +167,8 @@
   }
 }
 
-@keyframes twinkle {
+// Removed due to chromium 121 memory leak (See: https://issues.chromium.org/issues/323708859)
+/*@keyframes twinkle {
     50% { opacity: 0.2; }
 }
 
@@ -170,4 +176,4 @@
     0%   { transform: translate(0%, -50%); }
     50%  { transform: translate(-50%, -50%); }
     100% { transform: translate(0%, -50%); }
-}
+}*/


### PR DESCRIPTION
Infinite animations cause high CPU and memory usage since chromium 121.
This PR removes the dark-mode toggle animations completely:
- Stars not twinling
- Clouds not moving

There is still the infinite patreon bar but it doesn't look like it slows down the site as fast.

See https://issues.chromium.org/issues/323708859

