### PR TITLE
(feature) Add live run CTA to races page when no races in progress

### DIFF
--- a/app/races/in-progress-races.tsx
+++ b/app/races/in-progress-races.tsx
@@ -1,19 +1,25 @@
 "use client";
 
-import { Race, RaceParticipantWithLiveData } from "~app/races/races.types";
 import { Card, Col, Row } from "react-bootstrap";
-import styles from "../../src/components/css/LiveRun.module.scss";
 import { RaceTimer } from "~app/races/[race]/race-timer";
-import { PersonIcon } from "~src/icons/person-icon";
-import { ClockIcon } from "~src/icons/clock-icon";
-import { RacePlacings } from "~app/races/components/race-placings";
 import { RaceParticipantStatusOverview } from "~app/races/components/race-participant-status-overview";
+import { RacePlacings } from "~app/races/components/race-placings";
+import { Race, RaceParticipantWithLiveData } from "~app/races/races.types";
+import { ClockIcon } from "~src/icons/clock-icon";
+import { PersonIcon } from "~src/icons/person-icon";
+import styles from "../../src/components/css/LiveRun.module.scss";
 
 export const InProgressRaces = ({ races }: { races: Race[] }) => {
     if (races.length === 0) {
         return (
             <div className={"flex-center h3"}>
-                No races in progress currently
+                <div className="d-flex flex-column text-center">
+                    <p>No races in progress currently.</p>
+                    <p>
+                        Go check out some <a href="/live">live runs</a> while
+                        you wait!
+                    </p>
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
I thought it might be nice to offer an alternative to users by "guiding" them to the live runs page when no races are in progress.

![image](https://github.com/therungg/therun-frontend/assets/22936904/757a1002-d9a9-48de-9a87-3e87fade2eec)
