### PR TITLE
fix: Update Games page timeout limit to 60s to handle large game payloads

### DIFF
--- a/app/games/[game]/page.tsx
+++ b/app/games/[game]/page.tsx
@@ -5,6 +5,8 @@ import buildMetadata, { getGameImage } from "~src/utils/metadata";
 import { getGame } from "~src/components/game/get-game";
 
 export const revalidate = 60;
+// Increase Games Page timeout to 60 seconds since the payloads are gigantic for some games like SM64
+export const maxDuration = 60;
 
 interface PageProps {
     params: { game: string };


### PR DESCRIPTION
discussed offline. fixes 504s caused by vercel gateway timeouts for large game payloads

![image](https://github.com/therungg/therun-frontend/assets/87673558/97df2aeb-6505-4267-b15d-c8a54cc67241)
