### PR TITLE
feat: add pseudo-ErrorBoundary for session errors

### DIFF
--- a/app/api/after-login-redirect.ts
+++ b/app/api/after-login-redirect.ts
@@ -11,11 +11,16 @@ export async function afterLoginRedirect(request: NextRequest, postfix = "") {
     const code = request.nextUrl.searchParams.get("code");
     if (code) {
         const { id } = (await createSession(code)) || {};
+        const headers = new Headers();
+        if (id) {
+            headers.append(
+                "Set-Cookie",
+                `session_id=${id}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${MAX_AGE};`,
+            );
+        }
         const response = NextResponse.redirect(baseUrl, {
             status: 302,
-            headers: {
-                "Set-Cookie": `session_id=${id}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${MAX_AGE};`,
-            },
+            headers,
         });
         revalidatePath(baseUrl);
         return response;

--- a/app/header.tsx
+++ b/app/header.tsx
@@ -1,15 +1,23 @@
 import Topbar from "~src/components/topbar";
 
+interface HeaderProps {
+    username: string;
+    picture: string;
+    sessionError: string | null;
+}
+
 export const Header = ({
     username,
     picture,
-}: {
-    username?: string;
-    picture?: string;
-}) => {
+    sessionError,
+}: Partial<HeaderProps>) => {
     return (
         <header className="bg-body-secondary">
-            <Topbar username={username} picture={picture} />
+            <Topbar
+                username={username}
+                picture={picture}
+                sessionError={sessionError}
+            />
         </header>
     );
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,9 @@ import { Scripts } from "./scripts";
 import { getSession } from "~src/actions/session.action";
 import buildMetadata from "~src/utils/metadata";
 import { Viewport } from "next";
+import { SessionError } from "~src/common/session.error";
+import { User } from "types/session.types";
+import { SessionErrorBoundary } from "~src/components/errors/session.error-boundary";
 
 export const metadata = buildMetadata();
 export const viewport: Viewport = {
@@ -20,7 +23,16 @@ export default async function RootLayout({
 }: {
     children: React.ReactNode;
 }) {
-    const session = await getSession();
+    let sessionError = null;
+    let session!: User;
+    try {
+        session = await getSession();
+    } catch (error) {
+        if (error instanceof SessionError) {
+            sessionError = error;
+        }
+    }
+
     return (
         <html lang="en" suppressHydrationWarning>
             <body>
@@ -30,7 +42,9 @@ export default async function RootLayout({
                         username={session?.username}
                         picture={session?.picture}
                     />
-                    <Content>{children}</Content>
+                    <Content>
+                        {sessionError ? <SessionErrorBoundary /> : children}
+                    </Content>
                     <Footer />
                 </Providers>
             </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,13 +23,13 @@ export default async function RootLayout({
 }: {
     children: React.ReactNode;
 }) {
-    let sessionError = null;
+    let sessionError: string | null = null;
     let session!: User;
     try {
         session = await getSession();
     } catch (error) {
         if (error instanceof SessionError) {
-            sessionError = error;
+            sessionError = error.toString();
         }
     }
 
@@ -41,6 +41,7 @@ export default async function RootLayout({
                     <Header
                         username={session?.username}
                         picture={session?.picture}
+                        sessionError={sessionError}
                     />
                     <Content>
                         {sessionError ? <SessionErrorBoundary /> : children}

--- a/src/actions/reset-session.action.ts
+++ b/src/actions/reset-session.action.ts
@@ -1,0 +1,11 @@
+"use server";
+export const resetSession = async () => {
+    if (typeof window !== "undefined") return;
+    try {
+        const { cookies } = await import("next/headers");
+        cookies().delete("session_id");
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(error);
+    }
+};

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_SESSION = { id: "", username: "", picture: "" };

--- a/src/common/session.error.ts
+++ b/src/common/session.error.ts
@@ -1,0 +1,6 @@
+export class SessionError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "SessionError";
+    }
+}

--- a/src/components/errors/session.error-boundary.tsx
+++ b/src/components/errors/session.error-boundary.tsx
@@ -11,12 +11,15 @@ export const SessionErrorBoundary = () => {
         <div>
             <h2>Oops, there was an error configuring the session!</h2>
             <p>
-                You can reset your session by clicking the button below. Or, if
-                you&apos;re already logged in, you can manually logout and back
-                in.
+                Please reset your session by clicking the button below and then
+                login again.
             </p>
-            <button type="button" onClick={handleResetSession}>
-                Reset session?
+            <button
+                className="btn btn-primary"
+                type="button"
+                onClick={handleResetSession}
+            >
+                Reset session
             </button>
         </div>
     );

--- a/src/components/errors/session.error-boundary.tsx
+++ b/src/components/errors/session.error-boundary.tsx
@@ -1,0 +1,23 @@
+"use client";
+import React, { useCallback } from "react";
+import { resetSession } from "~src/actions/reset-session.action";
+
+export const SessionErrorBoundary = () => {
+    const handleResetSession = useCallback(async () => {
+        await resetSession();
+        window.location.reload();
+    }, [resetSession]);
+    return (
+        <div>
+            <h2>Oops, there was an error configuring the session!</h2>
+            <p>
+                You can reset your session by clicking the button below. Or, if
+                you&apos;re already logged in, you can manually logout and back
+                in.
+            </p>
+            <button type="button" onClick={handleResetSession}>
+                Reset session?
+            </button>
+        </div>
+    );
+};

--- a/src/components/topbar.tsx
+++ b/src/components/topbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Container, Nav, Navbar, NavDropdown } from "react-bootstrap";
 import dynamic from "next/dynamic";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { TwitchUser } from "./twitch/TwitchUser";
@@ -9,21 +9,27 @@ import { TwitchLoginButton } from "./twitch/TwitchLoginButton";
 import { getColorMode } from "~src/utils/colormode";
 import { Upload } from "react-bootstrap-icons";
 import { AutoCompletion } from "~src/components/search/autocompletion";
+import { resetSession } from "~src/actions/reset-session.action";
 
 const DarkModeSlider = dynamic(() => import("./dark-mode-slider"), {
     ssr: false,
 });
 
-const Topbar = ({
-    username,
-    picture,
-}: {
-    username?: string;
-    picture?: string;
-}) => {
+interface TopbarProps {
+    username: string;
+    picture: string;
+    sessionError: string | null;
+}
+
+const Topbar = ({ username, picture, sessionError }: Partial<TopbarProps>) => {
     const router = useRouter();
     const [show, setShow] = useState(false);
     const [dark, setDark] = useState(true);
+
+    const handleResetSession = useCallback(async () => {
+        await resetSession();
+        window.location.reload();
+    }, [resetSession]);
 
     useEffect(function () {
         setDark(getColorMode() !== "light");
@@ -134,7 +140,20 @@ const Topbar = ({
                                 </NavDropdown.Item>
                             </NavDropdown>
                         )}
-                        {!username && <TwitchLoginButton url="/api" />}
+                        {sessionError && (
+                            <div className="ms-2">
+                                <button
+                                    className="btn btn-primary"
+                                    type="button"
+                                    onClick={handleResetSession}
+                                >
+                                    Reset session
+                                </button>
+                            </div>
+                        )}
+                        {!username && !sessionError && (
+                            <TwitchLoginButton url="/api" />
+                        )}
                     </Nav>
                 </Navbar.Collapse>
             </Container>

--- a/src/components/topbar.tsx
+++ b/src/components/topbar.tsx
@@ -151,7 +151,7 @@ const Topbar = ({ username, picture, sessionError }: Partial<TopbarProps>) => {
                                 </button>
                             </div>
                         )}
-                        {!username && !sessionError && (
+                        {!sessionError && !username && (
                             <TwitchLoginButton url="/api" />
                         )}
                     </Nav>

--- a/src/lib/get-session-data.ts
+++ b/src/lib/get-session-data.ts
@@ -1,10 +1,25 @@
+import { SessionError } from "~src/common/session.error";
+
 export const getSessionData = async (sessionId: string): Promise<unknown> => {
     if (!sessionId) {
         return {};
     }
+
     const url = `https://6ob8kz9k4g.execute-api.eu-west-1.amazonaws.com/session?id=${sessionId}&returnUser=true`;
 
-    return (
-        await (await fetch(url, { next: { revalidate: 60 * 60 * 2 } })).json()
-    )?.result?.data;
+    try {
+        const response = await fetch(url, {
+            next: { revalidate: 60 * 60 * 2 },
+        });
+        const result = await response.json();
+        const session = result?.result?.data;
+
+        if (!session) {
+            throw new SessionError("Session not found");
+        }
+
+        return session;
+    } catch (error) {
+        throw new SessionError("An error occurred recovering session data");
+    }
 };


### PR DESCRIPTION
# What is this?

This PR adds error handling for the session endpoint. If it fails to retrieve an error it tends to bubble up into a very cryptic error for the user. This solves the issue by catching the errors, explicitly raising known errors, and displaying a recovery UX for the user to reset the session.

## How does this work?

- We assert that we've found a valid session on the server from the `getSessionData` function. If we don't we throw a new `SessionError`. And if crashes for any other reason, we'll still throw that same error. Double safety.
- We let the error bubble up all the way to the root of the application in our `layout.tsx` component.
- Since the `global-error.tsx` [mangles errors on the client and doesn't display in dev mode](https://nextjs.org/docs/app/building-your-application/routing/error-handling#handling-server-errors) we're opting for manual client-side error handling since this is not a sensitive error and is controlled.
- Once the error bubbles up we set a local variable for the error, render a component instead of children and then have a server action that can delete the cookie and reload the page.
- That's it!

BEFORE:

![image](https://github.com/therungg/therun-frontend/assets/87673558/5fc0ce0c-0474-4822-8371-072520ad4c84)

AFTER:

![image](https://github.com/therungg/therun-frontend/assets/87673558/199d5a0a-9934-4b7a-975e-9af54396dfd6)