### PR TITLE
feat: Add ability to count user route visits

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,8 +10,6 @@ import { Scripts } from "./scripts";
 import { getSession } from "~src/actions/session.action";
 import buildMetadata from "~src/utils/metadata";
 import { Viewport } from "next";
-import { SessionError } from "~src/common/session.error";
-import { User } from "types/session.types";
 import { SessionErrorBoundary } from "~src/components/errors/session.error-boundary";
 
 export const metadata = buildMetadata();
@@ -25,20 +23,12 @@ export default async function RootLayout({
 }: {
     children: React.ReactNode;
 }) {
-    let sessionError: string | null = null;
-    let session!: User;
-    try {
-        session = await getSession();
-    } catch (error) {
-        if (error instanceof SessionError) {
-            sessionError = error.toString();
-        }
-    }
+    const session = await getSession();
+    const sessionError = session.sessionError;
     const locale = await getLocale();
     // Providing all messages to the client
     // side is the easiest way to get started
     const messages = await getMessages();
-
     return (
         <html lang={locale} suppressHydrationWarning>
             <body>

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { redirectTournamentsMiddleware } from "./src/middlewares/redirect-tournaments.middleware";
+import { routeVisitMiddleware } from "./src/middlewares/route-visit.middleware";
+
+// Only return the response when you need a redirect or something
+const middlewareList = [routeVisitMiddleware, redirectTournamentsMiddleware];
+
+type MiddlewareFn = (
+    // eslint-disable-next-line no-unused-vars
+    request: NextRequest,
+    // eslint-disable-next-line no-unused-vars
+    response: NextResponse,
+) => NextResponse | void;
+
+function withMiddlewares(middlewares: MiddlewareFn[]) {
+    return async (request: NextRequest) => {
+        const response = NextResponse.next();
+
+        for (const middleware of middlewares) {
+            const result = await middleware(request, response);
+            if (result instanceof NextResponse) {
+                return result;
+            }
+        }
+
+        return response;
+    };
+}
+
+export const middleware = withMiddlewares(middlewareList);

--- a/src/actions/session.action.ts
+++ b/src/actions/session.action.ts
@@ -53,8 +53,10 @@ export const getSession = async (): Promise<User> => {
     } catch (error) {
         // For now we only want to handle _explicit_ failures when retrieving the session.
         if (error instanceof SessionError) {
-            // re-raise the error
-            throw error;
+            return {
+                ...DEFAULT_SESSION,
+                sessionError: error.toString(),
+            };
         }
 
         return DEFAULT_SESSION;

--- a/src/common/use-navigation-event.tsx
+++ b/src/common/use-navigation-event.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+// eslint-disable-next-line no-undef
+export function useNavigationEvent(callback: MutationCallback) {
+    const observerRef = useRef<MutationObserver>();
+
+    useEffect(() => {
+        const observer = new MutationObserver(callback);
+        const config = { subtree: true, childList: true };
+
+        observer.observe(document, config);
+        observerRef.current = observer;
+
+        return () => {
+            if (observerRef.current) {
+                observerRef.current.disconnect();
+            }
+        };
+    }, [callback]);
+}

--- a/src/common/use-session-visits.tsx
+++ b/src/common/use-session-visits.tsx
@@ -1,0 +1,22 @@
+import { useRef, useCallback } from "react";
+import { useNavigationEvent } from "./use-navigation-event";
+
+export const useSessionVisits = () => {
+    const STORAGE_KEY = "session_visits";
+    const previousUrlRef = useRef("");
+
+    const trackRouteVisit = useCallback(() => {
+        const previousUrl = previousUrlRef.current;
+        const currentUrl = window.location.pathname;
+
+        if (currentUrl !== previousUrl) {
+            previousUrlRef.current = currentUrl;
+            const visits = window.sessionStorage.getItem(STORAGE_KEY);
+            const sessionVisits = visits ? JSON.parse(visits) : {};
+            sessionVisits[currentUrl] = (sessionVisits[currentUrl] || 0) + 1;
+            sessionStorage.setItem(STORAGE_KEY, JSON.stringify(sessionVisits));
+        }
+    }, []);
+
+    useNavigationEvent(trackRouteVisit);
+};

--- a/src/middlewares/redirect-tournaments.middleware.ts
+++ b/src/middlewares/redirect-tournaments.middleware.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAllTournamentSlugs } from "~app/tournaments/tournament-list";
 
-export function middleware(request: NextRequest) {
+export const redirectTournamentsMiddleware = (
+    request: NextRequest,
+    // eslint-disable-next-line no-unused-vars
+    _response: NextResponse,
+) => {
     const reroutes = getAllTournamentSlugs();
 
     const shouldReroute = (reroute: string, pathname: string): boolean => {
@@ -20,6 +24,4 @@ export function middleware(request: NextRequest) {
             `${request.nextUrl.origin}/${redirect}${request.nextUrl.search}`,
         );
     }
-
-    return NextResponse.next();
-}
+};

--- a/src/middlewares/route-visit.middleware.ts
+++ b/src/middlewares/route-visit.middleware.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { COOKIE_KEY } from "~src/utils/cookies";
+
+const fileTypes = [
+    "png",
+    "jpg",
+    "jpeg",
+    "gif",
+    "svg",
+    "css",
+    "js",
+    "map",
+    "woff",
+    "woff2",
+    "ttf",
+    "ico",
+    "webp",
+    "webmanifest",
+];
+
+export const routeVisitMiddleware = (
+    request: NextRequest,
+    response: NextResponse,
+) => {
+    const url = request.nextUrl.clone();
+    const visitPath = url.pathname;
+
+    // Exclude API and resource routes
+    if (
+        visitPath.startsWith("/api") ||
+        visitPath.startsWith("/_next") ||
+        new RegExp(`.(${fileTypes.join("|")})$`).test(visitPath)
+    ) {
+        return;
+    }
+
+    const visitCookie = request.cookies.get(COOKIE_KEY.PAGE_VISITS);
+    let visits: Record<string, number> = {};
+    if (visitCookie) {
+        try {
+            visits = JSON.parse(visitCookie.value);
+        } catch (e) {
+            // Handle the case where the cookie is not valid JSON
+            visits = {};
+        }
+    }
+
+    // Update visit count
+    visits[visitPath] = (visits[visitPath] || 0) + 1;
+    const cookieValue = JSON.stringify(visits);
+    // Set updated visits in cookies
+    response.cookies.set(COOKIE_KEY.PAGE_VISITS, cookieValue);
+};

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -1,8 +1,17 @@
 import { getCookie, setCookie } from "cookies-next";
+import { ValuesOf } from "types/utility.types";
 
-type CookieKey = "scheme" | "session_id" | "races-message-read";
+export const COOKIE_KEY = {
+    SCHEME: "scheme",
+    SESSION_ID: "session_id",
+    RACES_MESSAGE_READ: "races-message-read",
+    PAGE_VISITS: "page_visits",
+} as const;
 
-export const getCookieKey = async (key: CookieKey, defaultValue?: string) => {
+export const getCookieKey = async (
+    key: ValuesOf<typeof COOKIE_KEY>,
+    defaultValue?: string,
+) => {
     // The `getCookie` function is not available on the server, imagine that
     // we have to access the scheme while Next.js is rendering the `<RootLayout />`
     // component (this happens server side). We can use the `cookies` function
@@ -15,6 +24,9 @@ export const getCookieKey = async (key: CookieKey, defaultValue?: string) => {
     return getCookie(key, { path: "/" }) ?? defaultValue;
 };
 
-export const setCookieData = (key: CookieKey, value: string) => {
+export const setCookieData = (
+    key: ValuesOf<typeof COOKIE_KEY>,
+    value: string,
+) => {
     setCookie(key, value, { path: "/" });
 };

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -1,4 +1,5 @@
 import { getCookie, setCookie } from "cookies-next";
+import { RequestCookie } from "next/dist/compiled/@edge-runtime/cookies";
 import { ValuesOf } from "types/utility.types";
 
 export const COOKIE_KEY = {
@@ -6,6 +7,7 @@ export const COOKIE_KEY = {
     SESSION_ID: "session_id",
     RACES_MESSAGE_READ: "races-message-read",
     PAGE_VISITS: "page_visits",
+    RECENT_VISITS: "recent_visits",
 } as const;
 
 export const getCookieKey = async (
@@ -29,4 +31,18 @@ export const setCookieData = (
     value: string,
 ) => {
     setCookie(key, value, { path: "/" });
+};
+
+export const parseCookie = (
+    cookieData: RequestCookie | undefined,
+    defaultValue?: unknown,
+) => {
+    if (cookieData) {
+        try {
+            return JSON.parse(cookieData.value);
+        } catch (e) {
+            return defaultValue;
+        }
+    }
+    return defaultValue;
 };

--- a/types/session.types.ts
+++ b/types/session.types.ts
@@ -4,6 +4,7 @@ export interface User {
     picture: string;
     roles?: Role[];
     moderatedGames?: string[];
+    sessionError?: string;
 }
 
 export type Role =


### PR DESCRIPTION
This PR adds the ability to maintain a log of all of the user route visits.

For anyone reading this: This is _not_ tracking, nor is it related to any kind of analytics. None of this data is persisted to the database. None of this data leaves the user's machine.

- All route changes are persisted in a new `page_visits` cookie that's updated via middleware
- All session visits are updated and stored in `sessionStorage` so that it gets garbage collected based on standard browser rules. This eliminates the need to manage this object manually.

Basically it's just a `{ [route: string]: number }` object so that we can eventually display this data to the user: routes visited this session and top routes historically.
