### PR TITLE
Only 5 categories by default on game page with button to show all! 

### DIFF
--- a/src/components/game/category-overview.tsx
+++ b/src/components/game/category-overview.tsx
@@ -18,7 +18,7 @@ export const CategoryOverview = ({
     game: string;
     setCurrentCategory: Dispatch<any>;
 }) => {
-    const [showAllCategories, setShowAllCategories] = useState(5);
+    const [categoriesCountLimit, setCategoriesCountLimit] = useState(5);
 
     return (
         <Table striped bordered hover responsive>
@@ -48,7 +48,7 @@ export const CategoryOverview = ({
                 </tr>
             </thead>
             <tbody>
-                {categories.slice(0, showAllCategories).map((category) => {
+                {categories.slice(0, categoriesCountLimit).map((category) => {
                     return (
                         category.pbLeaderboard[0] && (
                             <tr key={category.categoryName}>
@@ -103,6 +103,8 @@ export const CategoryOverview = ({
                                 </td>
                                 <td className="d-none d-md-table-cell text-nowrap">
                                     {category.stats.finishedAttemptCount}/
+                                    {/* {category.stats.finishedAttemptCount.toLocaleString()}/ */}
+                                    {/* {category.stats.attemptCount.toLocaleString()} ( */}
                                     {category.stats.attemptCount} (
                                     {(
                                         (category.stats.finishedAttemptCount /
@@ -112,28 +114,31 @@ export const CategoryOverview = ({
                                     %)
                                 </td>
                                 <td className="d-none d-md-table-cell">
-                                    {category.stats.uploadCount}
+                                    {category.stats.uploadCount.toLocaleString()}
                                 </td>
                             </tr>
                         )
                     );
                 })}
             </tbody>
-            <br />
             {categories.length > 5 ? (
-                showAllCategories === 5 ? (
+                categoriesCountLimit === 5 ? (
                     <button
-                        name="Show More"
-                        onClick={() => setShowAllCategories(100)}
+                        name="Show more categories"
+                        className="mt-2"
+                        onClick={() =>
+                            setCategoriesCountLimit(categories.length)
+                        }
                     >
-                        Show More Categories
+                        Show more categories
                     </button>
                 ) : (
                     <button
-                        name="Show Less"
-                        onClick={() => setShowAllCategories(5)}
+                        name="Show fewer categories"
+                        className="mt-2"
+                        onClick={() => setCategoriesCountLimit(5)}
                     >
-                        Show Less Categories
+                        Show fewer categories
                     </button>
                 )
             ) : null}

--- a/src/components/game/category-overview.tsx
+++ b/src/components/game/category-overview.tsx
@@ -19,6 +19,7 @@ export const CategoryOverview = ({
     setCurrentCategory: Dispatch<any>;
 }) => {
     const [categoriesCountLimit, setCategoriesCountLimit] = useState(5);
+    const MINIMUM_CATEGORIES_LIMIT: number = 5;
 
     return (
         <Table striped bordered hover responsive>
@@ -114,15 +115,15 @@ export const CategoryOverview = ({
                                     %)
                                 </td>
                                 <td className="d-none d-md-table-cell">
-                                    {category.stats.uploadCount.toLocaleString()}
+                                    {category.stats.uploadCount}
                                 </td>
                             </tr>
                         )
                     );
                 })}
             </tbody>
-            {categories.length > 5 ? (
-                categoriesCountLimit === 5 ? (
+            {categories.length > MINIMUM_CATEGORIES_LIMIT ? (
+                categoriesCountLimit === MINIMUM_CATEGORIES_LIMIT ? (
                     <button
                         name="Show more categories"
                         className="mt-2"
@@ -136,7 +137,9 @@ export const CategoryOverview = ({
                     <button
                         name="Show fewer categories"
                         className="mt-2"
-                        onClick={() => setCategoriesCountLimit(5)}
+                        onClick={() =>
+                            setCategoriesCountLimit(MINIMUM_CATEGORIES_LIMIT)
+                        }
                     >
                         Show fewer categories
                     </button>

--- a/src/components/game/category-overview.tsx
+++ b/src/components/game/category-overview.tsx
@@ -6,7 +6,7 @@ import {
     UserGameCategoryLink,
     UserLink,
 } from "../links/links";
-import { Dispatch } from "react";
+import { Dispatch, useState } from "react";
 import { InfoTooltip } from "../tooltip";
 
 export const CategoryOverview = ({
@@ -18,6 +18,8 @@ export const CategoryOverview = ({
     game: string;
     setCurrentCategory: Dispatch<any>;
 }) => {
+    const [showAllCategories, setShowAllCategories] = useState(5);
+
     return (
         <Table striped bordered hover responsive>
             <thead>
@@ -46,7 +48,7 @@ export const CategoryOverview = ({
                 </tr>
             </thead>
             <tbody>
-                {categories.map((category) => {
+                {categories.slice(0, showAllCategories).map((category) => {
                     return (
                         category.pbLeaderboard[0] && (
                             <tr key={category.categoryName}>
@@ -117,6 +119,24 @@ export const CategoryOverview = ({
                     );
                 })}
             </tbody>
+            <br />
+            {categories.length > 5 ? (
+                showAllCategories === 5 ? (
+                    <button
+                        name="Show More"
+                        onClick={() => setShowAllCategories(100)}
+                    >
+                        Show More Categories
+                    </button>
+                ) : (
+                    <button
+                        name="Show Less"
+                        onClick={() => setShowAllCategories(5)}
+                    >
+                        Show Less Categories
+                    </button>
+                )
+            ) : null}
         </Table>
     );
 };

--- a/src/components/game/category-overview.tsx
+++ b/src/components/game/category-overview.tsx
@@ -78,7 +78,9 @@ export const CategoryOverview = ({
                                         game={game}
                                     >
                                         <DurationToFormatted
-                                            duration={category.pbLeaderboard[0].stat.toString()}
+                                            duration={
+                                                category.pbLeaderboard[0].stat
+                                            }
                                         />
                                     </UserGameCategoryLink>
                                     &nbsp;(
@@ -103,8 +105,6 @@ export const CategoryOverview = ({
                                 </td>
                                 <td className="d-none d-md-table-cell text-nowrap">
                                     {category.stats.finishedAttemptCount}/
-                                    {/* {category.stats.finishedAttemptCount.toLocaleString()}/ */}
-                                    {/* {category.stats.attemptCount.toLocaleString()} ( */}
                                     {category.stats.attemptCount} (
                                     {(
                                         (category.stats.finishedAttemptCount /


### PR DESCRIPTION
In order to fix #16 
By default now only the top 5 categories per game are shown with a button to show the rest. If a game has less then 5 categories the button doesn't show. 

This is my first pull request EVER. Let me know if anything is wrong with the code, not sure if you have any specific formatting rules or so on your code.