### PR TITLE
Fix title not decoding usernames correctly

### DIFF
--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 import { OpenGraphType } from "next/dist/lib/metadata/types/opengraph-types";
 import { getBaseUrl } from "~src/actions/base-url.action";
-import { safeEncodeURI } from "./uri";
+import { safeDecodeURI, safeEncodeURI } from "./uri";
 
 declare type OpenGraphImage = {
     url: string | URL;
@@ -31,8 +31,10 @@ export interface MetadataProps {
 export default function buildMetadata(props?: MetadataProps): Metadata {
     const defaultImageUrl = "/therun-no-url-with-black-background.png";
     const title =
-        props?.absoluteTitle ||
-        `The Run - ${props?.title || "Speedrun Statistics"}`;
+        safeDecodeURI(props?.absoluteTitle || "") ||
+        `The Run - ${
+            safeDecodeURI(props?.title || "") || "Speedrun Statistics"
+        }`;
     const description =
         props?.description ||
         "The Run - a free tool for speedrun statistics. Explore leaderboards, check out live runs, and easily manage your own speedrun data!";


### PR DESCRIPTION
BEFORE:
<img width="242" alt="image" src="https://github.com/user-attachments/assets/6a49469b-56d3-491a-9419-20c99b5f09dd">

AFTER:
<img width="294" alt="image" src="https://github.com/user-attachments/assets/a0238e11-cfcf-41a2-a2be-8e7effcf5c45">