### PR TITLE
Properly highlight the search result items

### DIFF
--- a/src/components/search/search-results-panel.component.tsx
+++ b/src/components/search/search-results-panel.component.tsx
@@ -80,11 +80,11 @@ const SearchResultItem = React.memo<SearchResultItemProps>(({ result }) => {
     const url =
         result.type === "user" ? `/${result.key}` : `/games/${result.key}`;
     return (
-        <dd className="list-group-item-action m-0">
+        <dd className="m-0">
             <Link
                 href={url}
                 title={result.key}
-                className="d-block text-decoration-none px-3 py-1 text-truncate text-body lh-sm"
+                className="list-group-item-action d-block text-decoration-none px-3 py-1 text-truncate text-body lh-sm"
             >
                 <FuzzyMatchHighlight
                     result={result.key}


### PR DESCRIPTION
### Description

* move the list-group-item-action to the target

This PR moves the item-action class to the target to properly focus the item when using keyboard navigation

![image](https://github.com/user-attachments/assets/94a96fbb-c3d7-40ff-958a-44ee78713fce)
