### PR TITLE
Fix profile photo being tiny randomly

### DIFF
--- a/src/components/twitch/TwitchUser.tsx
+++ b/src/components/twitch/TwitchUser.tsx
@@ -23,13 +23,9 @@ export const TwitchUser: React.FunctionComponent<TwitchUserProps> = ({
                         alt={username}
                         width={32}
                         height={32}
-                        style={{
-                            maxWidth: "100%",
-                            height: "auto",
-                        }}
                     />
                 </div>
-                <div className="ms-2 ">
+                <div className="ms-2">
                     <NameAsPatreon name={username} />
                 </div>
             </Nav.Item>


### PR DESCRIPTION
There is no need for the profile photo to be responsive, so I removed responsiveness. This is what was causing the weird quirk on that one viewport size.

Resolves #316