### PR TITLE
Handle empty runs for users

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -58,7 +58,7 @@ export default async function Page(props: PageProps) {
         });
     }
 
-    const runs = await getUserRuns(username);
+    const runs = (await getUserRuns(username)) || [];
 
     const allRunsRunMap = getRunmap(runs);
 


### PR DESCRIPTION
### Description

A user reported on discord that he did reupload runs with a fresh history, however that did break his profile completely.
It seems like the user profile does not have "any runs" right now, thus returning a 500.. 🤔 

Basically error handling