### PR TITLE
feat: add current user live panel to frontpage

### DIFF
--- a/app/(new-layout)/frontpage/frontpage.tsx
+++ b/app/(new-layout)/frontpage/frontpage.tsx
@@ -1,9 +1,10 @@
 import styles from './frontpage.module.scss';
+import CurrentUserLivePanel from './panels/current-user-live-panel/current-user-live-panel';
 import { LatestPbsPanel } from './panels/latest-pbs-panel/latest-pbs-panel';
 import { LiveRunsPanel } from './panels/live-runs-panel/live-runs-panel';
+import PatreonPanel from './panels/patreon-panel/patreon-panel';
 import RacePanel from './panels/race-panel/race-panel';
 import StatsPanel from './panels/stats-panel/stats-panel';
-import PatreonPanel from './panels/patreon-panel/patreon-panel';
 
 export default async function FrontPage() {
     return (
@@ -22,6 +23,7 @@ export default async function FrontPage() {
                     <StatsPanel />
                 </div>
                 <div className="col col-lg-6 col-xl-5 col-12">
+                    <CurrentUserLivePanel />
                     <RacePanel />
                     <PatreonPanel />
                     <LatestPbsPanel />

--- a/app/(new-layout)/frontpage/panels/current-user-live-panel/current-user-live-panel-view.tsx
+++ b/app/(new-layout)/frontpage/panels/current-user-live-panel/current-user-live-panel-view.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { LiveRun } from '~app/(old-layout)/live/live.types';
+import { useLiveRunsWebsocket } from '~src/components/websocket/use-reconnect-websocket';
+import styles from './current-user-live-panel.module.scss';
+
+interface CurrentUserLivePanelViewProps {
+    initialLiveData: LiveRun;
+    username: string;
+}
+
+export const CurrentUserLivePanelView: React.FC<
+    CurrentUserLivePanelViewProps
+> = ({ initialLiveData, username }) => {
+    const [liveRun, setLiveRun] = useState<LiveRun | undefined>(
+        initialLiveData,
+    );
+    const lastMessage = useLiveRunsWebsocket(username);
+
+    useEffect(() => {
+        if (lastMessage !== null) {
+            if (lastMessage.type === 'UPDATE') {
+                setLiveRun(lastMessage.run);
+            }
+            if (lastMessage.type === 'DELETE') {
+                setLiveRun(undefined);
+            }
+        }
+    }, [lastMessage]);
+
+    // Hide panel if run ended
+    if (!liveRun) {
+        return null;
+    }
+
+    return (
+        <Link href={`/live/${username}`} className={styles.panelLink}>
+            <div className={styles.liveRunPanel}>
+                <div>Live run content placeholder</div>
+            </div>
+        </Link>
+    );
+};

--- a/app/(new-layout)/frontpage/panels/current-user-live-panel/current-user-live-panel-view.tsx
+++ b/app/(new-layout)/frontpage/panels/current-user-live-panel/current-user-live-panel-view.tsx
@@ -1,8 +1,14 @@
 'use client';
 
+import Image from 'next/image';
 import Link from 'next/link';
+import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
 import { LiveRun } from '~app/(old-layout)/live/live.types';
+import { LiveSplitTimerComponent } from '~app/(old-layout)/live/live-split-timer.component';
+import { GameImage } from '~src/components/image/gameimage';
+import { LiveIcon } from '~src/components/live/live-user-run';
+import { DurationToFormatted } from '~src/components/util/datetime';
 import { useLiveRunsWebsocket } from '~src/components/websocket/use-reconnect-websocket';
 import styles from './current-user-live-panel.module.scss';
 
@@ -18,6 +24,12 @@ export const CurrentUserLivePanelView: React.FC<
         initialLiveData,
     );
     const lastMessage = useLiveRunsWebsocket(username);
+    const { theme } = useTheme();
+    const [isDark, setIsDark] = useState(true);
+
+    useEffect(() => {
+        setIsDark(theme !== 'light');
+    }, [theme]);
 
     useEffect(() => {
         if (lastMessage !== null) {
@@ -35,10 +47,117 @@ export const CurrentUserLivePanelView: React.FC<
         return null;
     }
 
+    // Calculate progress percentage for progress bar
+    const progressPercentage = liveRun.pb
+        ? Math.min(100, (liveRun.currentTime / liveRun.pb) * 100)
+        : 0;
+
     return (
         <Link href={`/live/${username}`} className={styles.panelLink}>
             <div className={styles.liveRunPanel}>
-                <div>Live run content placeholder</div>
+                {/* Game Image or Logo */}
+                <div className={styles.imageContainer}>
+                    {liveRun.gameImage &&
+                    liveRun.gameImage.length > 0 &&
+                    liveRun.gameImage !== 'noimage' ? (
+                        <GameImage
+                            alt={liveRun.game}
+                            src={liveRun.gameImage}
+                            quality="small"
+                            height={120}
+                            width={90}
+                            className={styles.gameImage}
+                        />
+                    ) : (
+                        <Image
+                            alt="Logo"
+                            src={
+                                isDark
+                                    ? '/logo_dark_theme_no_text_transparent.png'
+                                    : '/logo_light_theme_no_text_transparent.png'
+                            }
+                            width={75}
+                            height={75}
+                            className={styles.fallbackLogo}
+                        />
+                    )}
+                </div>
+
+                {/* Main Content */}
+                <div className={styles.content}>
+                    <div className={styles.header}>
+                        <div className={styles.titleSection}>
+                            <div className={styles.liveIndicator}>
+                                <LiveIcon height={20} dark={isDark} />
+                                <span className={styles.liveText}>
+                                    Your Live Run
+                                </span>
+                            </div>
+                            {liveRun.currentlyStreaming && (
+                                <span className={styles.streamingBadge}>
+                                    Streaming
+                                </span>
+                            )}
+                        </div>
+                    </div>
+
+                    <div className={styles.gameInfo}>
+                        <div className={styles.gameName}>{liveRun.game}</div>
+                        <div className={styles.categoryName}>
+                            {liveRun.category}
+                        </div>
+                    </div>
+
+                    <div className={styles.runStats}>
+                        <div className={styles.timerSection}>
+                            <LiveSplitTimerComponent
+                                liveRun={liveRun}
+                                dark={isDark}
+                                withDiff={false}
+                                className={styles.timerBody}
+                                timerClassName={styles.timer}
+                            />
+                        </div>
+
+                        <div className={styles.splitInfo}>
+                            <div className={styles.currentSplit}>
+                                Split: {liveRun.currentSplitName}
+                            </div>
+                            {liveRun.pb && (
+                                <div className={styles.pbInfo}>
+                                    PB:{' '}
+                                    <DurationToFormatted
+                                        duration={liveRun.pb}
+                                    />
+                                </div>
+                            )}
+                            {liveRun.delta !== undefined && (
+                                <div
+                                    className={`${styles.delta} ${
+                                        liveRun.delta >= 0
+                                            ? styles.deltaBehind
+                                            : styles.deltaAhead
+                                    }`}
+                                >
+                                    {liveRun.delta >= 0 ? '+' : ''}
+                                    <DurationToFormatted
+                                        duration={Math.abs(liveRun.delta)}
+                                    />
+                                </div>
+                            )}
+                        </div>
+                    </div>
+
+                    {/* Progress Bar */}
+                    {liveRun.pb && (
+                        <div className={styles.progressBarContainer}>
+                            <div
+                                className={styles.progressBar}
+                                style={{ width: `${progressPercentage}%` }}
+                            />
+                        </div>
+                    )}
+                </div>
             </div>
         </Link>
     );

--- a/app/(new-layout)/frontpage/panels/current-user-live-panel/current-user-live-panel.module.scss
+++ b/app/(new-layout)/frontpage/panels/current-user-live-panel/current-user-live-panel.module.scss
@@ -1,0 +1,366 @@
+@import '../../../styles/design-tokens';
+@import '../../../styles/mixins';
+
+// ============================================
+// Live Run Panel - Main Container
+// ============================================
+
+.panelLink {
+    text-decoration: none;
+    color: inherit;
+    display: block;
+}
+
+.liveRunPanel {
+    position: relative;
+    display: flex;
+    gap: $spacing-lg;
+    padding: $spacing-lg;
+    background-color: var(--bs-tertiary-bg);
+    border-radius: $radius-lg;
+    border: 2px solid var(--bs-primary);
+    box-shadow: 0 0 0 0 rgba(var(--bs-primary-rgb), 0.4);
+    transition: all $transition-base;
+    overflow: hidden;
+
+    // Animated pulsing border and glow effect
+    animation: pulse-glow 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+
+    &:hover {
+        transform: translateY($hover-lift);
+        box-shadow: $shadow-lg, 0 0 20px rgba(var(--bs-primary-rgb), 0.3);
+        border-color: var(--bs-primary);
+    }
+
+    &:active {
+        transform: translateY($active-lift);
+    }
+
+    // Responsive layout
+    @media (max-width: 768px) {
+        flex-direction: column;
+        gap: $spacing-md;
+        padding: $spacing-md;
+    }
+}
+
+// ============================================
+// Pulse Animation
+// ============================================
+
+@keyframes pulse-glow {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 rgba(var(--bs-primary-rgb), 0.4),
+            0 0 15px rgba(var(--bs-primary-rgb), 0.2);
+    }
+
+    50% {
+        box-shadow: 0 0 0 4px rgba(var(--bs-primary-rgb), 0),
+            0 0 25px rgba(var(--bs-primary-rgb), 0.4);
+    }
+}
+
+// ============================================
+// Image Container
+// ============================================
+
+.imageContainer {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 90px;
+    height: 120px;
+    border-radius: $radius-md;
+    overflow: hidden;
+    background: linear-gradient(
+        135deg,
+        rgba(var(--bs-primary-rgb), 0.05),
+        rgba(var(--bs-primary-rgb), 0.1)
+    );
+    box-shadow: $shadow-sm;
+
+    @media (max-width: 768px) {
+        width: 100%;
+        height: auto;
+        min-height: 120px;
+    }
+}
+
+.gameImage {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.fallbackLogo {
+    opacity: 0.8;
+}
+
+// ============================================
+// Main Content
+// ============================================
+
+.content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-md;
+    min-width: 0;
+}
+
+// ============================================
+// Header Section
+// ============================================
+
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $spacing-sm;
+}
+
+.titleSection {
+    display: flex;
+    align-items: center;
+    gap: $spacing-md;
+    flex-wrap: wrap;
+}
+
+.liveIndicator {
+    display: flex;
+    align-items: center;
+    gap: $spacing-sm;
+}
+
+.liveText {
+    font-size: 0.9rem;
+    font-weight: $heading-font-weight;
+    color: var(--bs-primary);
+    letter-spacing: $label-letter-spacing;
+}
+
+.streamingBadge {
+    @include status-badge;
+    background: linear-gradient(
+        135deg,
+        rgba(220, 53, 69, 0.15),
+        rgba(220, 53, 69, 0.25)
+    );
+    color: var(--bs-danger);
+    font-size: 0.75rem;
+    padding: 0.25rem 0.6rem;
+    animation: pulse-badge 2s ease-in-out infinite;
+}
+
+@keyframes pulse-badge {
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.7;
+    }
+}
+
+// ============================================
+// Game Info Section
+// ============================================
+
+.gameInfo {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-xs;
+}
+
+.gameName {
+    font-size: 1.1rem;
+    font-weight: $heading-font-weight;
+    line-height: 1.3;
+    letter-spacing: $heading-letter-spacing;
+    color: var(--bs-body-color);
+}
+
+.categoryName {
+    font-size: 0.9rem;
+    color: var(--bs-secondary-color);
+    font-weight: 500;
+}
+
+// ============================================
+// Run Stats Section
+// ============================================
+
+.runStats {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-md;
+}
+
+.timerSection {
+    display: flex;
+    align-items: center;
+}
+
+.timerBody {
+    display: flex;
+    align-items: baseline;
+    gap: $spacing-sm;
+}
+
+.timer {
+    @include monospace-value;
+    font-size: 1.8rem;
+    color: var(--bs-primary);
+    line-height: 1;
+
+    @media (max-width: 768px) {
+        font-size: 1.5rem;
+    }
+}
+
+// ============================================
+// Split Info Section
+// ============================================
+
+.splitInfo {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: $spacing-lg;
+    font-size: 0.9rem;
+
+    @media (max-width: 768px) {
+        gap: $spacing-md;
+        font-size: 0.85rem;
+    }
+}
+
+.currentSplit {
+    font-weight: 500;
+    color: var(--bs-body-color);
+}
+
+.pbInfo {
+    @include monospace-value;
+    font-size: 0.9rem;
+    color: var(--bs-secondary-color);
+}
+
+// ============================================
+// Delta (Time Difference) - Color Coded
+// ============================================
+
+.delta {
+    @include monospace-value;
+    font-size: 0.9rem;
+    font-weight: 700;
+    padding: 0.25rem 0.6rem;
+    border-radius: $radius-sm;
+    transition: all $transition-fast;
+}
+
+// Green when ahead of PB (negative delta)
+.deltaAhead {
+    color: #28a745;
+    background: rgba(40, 167, 69, 0.1);
+
+    [data-bs-theme='dark'] & {
+        color: #5cb85c;
+        background: rgba(92, 184, 92, 0.15);
+    }
+}
+
+// Red when behind PB (positive delta)
+.deltaBehind {
+    color: #dc3545;
+    background: rgba(220, 53, 69, 0.1);
+
+    [data-bs-theme='dark'] & {
+        color: #e57373;
+        background: rgba(229, 115, 115, 0.15);
+    }
+}
+
+// ============================================
+// Progress Bar
+// ============================================
+
+.progressBarContainer {
+    position: relative;
+    width: 100%;
+    height: 6px;
+    background-color: rgba(var(--bs-primary-rgb), 0.1);
+    border-radius: $radius-sm;
+    overflow: hidden;
+    margin-top: $spacing-xs;
+}
+
+.progressBar {
+    height: 100%;
+    background: linear-gradient(
+        90deg,
+        rgba(var(--bs-primary-rgb), 0.6),
+        rgba(var(--bs-primary-rgb), 1)
+    );
+    border-radius: $radius-sm;
+    transition: width 0.3s ease-out;
+    position: relative;
+
+    // Animated shimmer effect
+    &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: linear-gradient(
+            90deg,
+            transparent,
+            rgba(255, 255, 255, 0.3),
+            transparent
+        );
+        animation: shimmer 2s infinite;
+    }
+}
+
+@keyframes shimmer {
+    0% {
+        transform: translateX(-100%);
+    }
+
+    100% {
+        transform: translateX(100%);
+    }
+}
+
+// ============================================
+// Dark Mode Adjustments
+// ============================================
+
+[data-bs-theme='dark'] {
+    .liveRunPanel {
+        background-color: var(--bs-tertiary-bg);
+        border-color: var(--bs-primary);
+        box-shadow: 0 0 0 0 rgba(var(--bs-primary-rgb), 0.5);
+
+        &:hover {
+            box-shadow: $shadow-lg, 0 0 25px rgba(var(--bs-primary-rgb), 0.4);
+        }
+    }
+
+    .imageContainer {
+        background: linear-gradient(
+            135deg,
+            rgba(var(--bs-primary-rgb), 0.08),
+            rgba(var(--bs-primary-rgb), 0.15)
+        );
+    }
+
+    .progressBarContainer {
+        background-color: rgba(var(--bs-primary-rgb), 0.15);
+    }
+}

--- a/app/(new-layout)/frontpage/panels/current-user-live-panel/current-user-live-panel.tsx
+++ b/app/(new-layout)/frontpage/panels/current-user-live-panel/current-user-live-panel.tsx
@@ -1,0 +1,35 @@
+import { Panel } from '~app/(new-layout)/components/panel.component';
+import { getSession } from '~src/actions/session.action';
+import { getLiveRunForUser } from '~src/lib/live-runs';
+import { CurrentUserLivePanelView } from './current-user-live-panel-view';
+
+export default async function CurrentUserLivePanel() {
+    const session = await getSession();
+
+    // No session = no panel
+    if (!session?.username) {
+        return null;
+    }
+
+    // Fetch live run data
+    const liveData = await getLiveRunForUser(session.username);
+
+    // No active run = no panel
+    if (!liveData || (Array.isArray(liveData) && liveData.length === 0)) {
+        return null;
+    }
+
+    return (
+        <Panel
+            subtitle="Currently Running"
+            title="Your Live Run"
+            link={{ url: `/live/${session.username}`, text: 'View Details' }}
+            className="p-4"
+        >
+            <CurrentUserLivePanelView
+                initialLiveData={liveData}
+                username={session.username}
+            />
+        </Panel>
+    );
+}

--- a/app/(new-layout)/frontpage/panels/live-runs-panel/live-runs-view.tsx
+++ b/app/(new-layout)/frontpage/panels/live-runs-panel/live-runs-view.tsx
@@ -97,7 +97,7 @@ export const LiveRunView = ({
                     xl={6}
                     className={clsx(
                         styles.streamWrapper,
-                        'bg-black order-1 order-xl-2 d-flex align-items-center justify-content-center',
+                        'bg-body order-1 order-xl-2 d-flex align-items-center justify-content-center',
                     )}
                 >
                     {/* Improvement: 16x9 Ratio lock */}

--- a/docs/plans/2026-01-30-configurable-frontpage-panels-design.md
+++ b/docs/plans/2026-01-30-configurable-frontpage-panels-design.md
@@ -1,0 +1,348 @@
+# Configurable Frontpage Panels - Design Document
+
+**Date:** 2026-01-30
+**Status:** Approved
+**Complexity:** Medium (2-3 days)
+
+## Overview
+
+Enable users to customize their frontpage experience by dragging panels to reorder them, moving them between columns, and hiding/showing panels. Configuration persists in the database and syncs across devices.
+
+## User Experience
+
+### Drag-and-Drop Interaction
+
+- Panels are always draggable for logged-in users (no toggle needed)
+- Small grip icon (⋮⋮) appears on hover in top-right of panel tab
+- Grip icon always visible on touch devices
+- Users drag panels to reorder within columns or move between columns
+
+### Visual Feedback
+
+- **Dragging panel:** Slight opacity (0.6), lifted shadow, follows cursor
+- **Drop zones:** Highlight with dashed border when dragging over
+- **Other panels:** Shift smoothly to make space (CSS transitions)
+- **Cursor:** Changes to `grabbing` during drag
+
+### Hiding Panels
+
+- Small eye icon (👁) next to drag handle
+- Click to hide → panel fades out, others shift to fill space
+- **Minimum 3 visible panels enforced** - hide button disabled when at minimum
+- Toast notification: "Panel hidden. Restore from dropdown ↑"
+
+### Restoring Hidden Panels
+
+- "Hidden Panels (2)" button in frontpage header (only shows if panels are hidden)
+- Dropdown menu lists hidden panels with restore icons
+- Click to restore → panel animates back to last known position
+
+### Saving
+
+- Auto-save on every drop/hide/restore
+- Optimistic updates (instant UI, sync in background)
+- Subtle "Saved" checkmark briefly after save completes
+
+### Responsive Behavior
+
+- **Desktop:** Two-column layout as configured
+- **Mobile:** Single column, respects visibility but ignores column assignment
+
+## Data Model
+
+### Database Schema
+
+Add to existing `users` table:
+```sql
+ALTER TABLE users ADD COLUMN frontpage_config JSONB;
+```
+
+### Config Structure
+
+```typescript
+type PanelId = 'live-runs' | 'stats' | 'current-user-live' | 'race' | 'patreon' | 'latest-pbs'
+type ColumnId = 'left' | 'right'
+
+type PanelConfig = {
+  panels: Array<{
+    id: PanelId
+    visible: boolean
+    order: number
+    column: ColumnId
+  }>
+}
+```
+
+### Default Configuration
+
+```typescript
+const DEFAULT_FRONTPAGE_CONFIG = {
+  panels: [
+    { id: 'live-runs', visible: true, order: 0, column: 'left' },
+    { id: 'stats', visible: true, order: 1, column: 'left' },
+    { id: 'current-user-live', visible: true, order: 0, column: 'right' },
+    { id: 'race', visible: true, order: 1, column: 'right' },
+    { id: 'patreon', visible: true, order: 2, column: 'right' },
+    { id: 'latest-pbs', visible: true, order: 3, column: 'right' }
+  ]
+}
+```
+
+Used when:
+- User is not logged in (guest view)
+- User is logged in but `frontpageConfig` is null
+- Saved config is invalid or corrupted
+
+## Component Architecture
+
+### Server Components
+
+**frontpage.tsx:**
+- Load user session
+- Load `frontpageConfig` from users table
+- Render all 6 panel server components
+- Pass config + panels to FrontpageLayout client component
+
+**Panels remain server components:**
+- No changes to individual panel components
+- They continue to fetch their own data server-side
+
+### Client Components
+
+**FrontpageLayout.tsx (new):**
+- Receives config and rendered panel components as props
+- Wraps everything in @dnd-kit DndContext
+- Manages drag-and-drop state
+- Renders two droppable columns
+- Handles hide/show/restore logic
+- Calls server action on config changes
+
+**DraggablePanel.tsx (new):**
+- Wrapper around each panel
+- Adds drag handle (grip icon)
+- Adds hide button (eye icon)
+- Uses @dnd-kit's `useSortable` hook
+- Applies drag styles and animations
+
+**HiddenPanelsDropdown.tsx (new):**
+- Dropdown in frontpage header
+- Shows count of hidden panels
+- Lists hidden panels with restore buttons
+- Only renders if panels are hidden
+
+### Panel Registry
+
+**src/lib/frontpage-panels.ts (new):**
+```typescript
+import LiveRunsPanel from '~app/(new-layout)/frontpage/panels/live-runs-panel/live-runs-panel'
+import StatsPanel from '~app/(new-layout)/frontpage/panels/stats-panel/stats-panel'
+// ... etc
+
+export const PANEL_REGISTRY = {
+  'live-runs': LiveRunsPanel,
+  'stats': StatsPanel,
+  'current-user-live': CurrentUserLivePanel,
+  'race': RacePanel,
+  'patreon': PatreonPanel,
+  'latest-pbs': LatestPbsPanel,
+} as const
+
+export const PANEL_METADATA = {
+  'live-runs': { name: 'Live Runs', defaultColumn: 'left' },
+  'stats': { name: 'Stats', defaultColumn: 'left' },
+  'current-user-live': { name: 'Your Live Run', defaultColumn: 'right' },
+  'race': { name: 'Races', defaultColumn: 'right' },
+  'patreon': { name: 'Patreon', defaultColumn: 'right' },
+  'latest-pbs': { name: 'Latest PBs', defaultColumn: 'right' },
+} as const
+```
+
+## Server Actions & API
+
+**src/actions/frontpage-config.action.ts (new):**
+
+```typescript
+'use server'
+
+import { getSession } from './session.action'
+import { db } from '~src/db'
+import { users } from '~src/db/schema'
+import { eq } from 'drizzle-orm'
+
+// Get user's config, returns default if not set
+export async function getFrontpageConfig(): Promise<PanelConfig> {
+  const session = await getSession()
+  if (!session?.userId) return DEFAULT_FRONTPAGE_CONFIG
+
+  const user = await db.select().from(users).where(eq(users.id, session.userId))
+  return user[0]?.frontpageConfig ?? DEFAULT_FRONTPAGE_CONFIG
+}
+
+// Update config with validation
+export async function updateFrontpageConfig(config: PanelConfig): Promise<{ success: boolean, error?: string }> {
+  const session = await getSession()
+  if (!session?.userId) {
+    return { success: false, error: 'Not authenticated' }
+  }
+
+  // Validation
+  const visibleCount = config.panels.filter(p => p.visible).length
+  if (visibleCount < 3) {
+    return { success: false, error: 'Must have at least 3 visible panels' }
+  }
+
+  const validPanelIds = Object.keys(PANEL_REGISTRY)
+  const allValid = config.panels.every(p => validPanelIds.includes(p.id))
+  if (!allValid) {
+    return { success: false, error: 'Invalid panel configuration' }
+  }
+
+  // Save
+  await db.update(users)
+    .set({ frontpageConfig: config })
+    .where(eq(users.id, session.userId))
+
+  return { success: true }
+}
+
+// Reset to defaults
+export async function resetFrontpageConfig(): Promise<void> {
+  const session = await getSession()
+  if (!session?.userId) throw new Error('Not authenticated')
+
+  await db.update(users)
+    .set({ frontpageConfig: null })
+    .where(eq(users.id, session.userId))
+}
+```
+
+**Error handling:**
+- Save fails → revert to previous layout, show error toast
+- Invalid config in DB → fall back to default
+- Missing panels in saved config → merge with defaults (handles future panel additions)
+
+## @dnd-kit Implementation
+
+**Dependencies to install:**
+```bash
+npm install @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
+```
+
+**DndContext setup in FrontpageLayout:**
+```typescript
+import { DndContext, DragEndEvent, DragOverlay, closestCorners } from '@dnd-kit/core'
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
+
+// Handle drag end
+function handleDragEnd(event: DragEndEvent) {
+  const { active, over } = event
+  if (!over) return
+
+  // Determine new position and column
+  const draggedPanelId = active.id
+  const targetColumn = over.data.current?.column || 'left'
+
+  // Update config optimistically
+  // Call updateFrontpageConfig server action
+  // Show save indicator
+}
+```
+
+**Sortable columns:**
+- Each column is a separate `SortableContext`
+- Allows dragging between columns
+- `verticalListSortingStrategy` for vertical panel stacking
+
+**DraggablePanel component:**
+```typescript
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+
+function DraggablePanel({ id, children, onHide }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+  }
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <div className="drag-handle" {...attributes} {...listeners}>⋮⋮</div>
+      <button onClick={onHide}>👁</button>
+      {children}
+    </div>
+  )
+}
+```
+
+**Accessibility:**
+- @dnd-kit provides keyboard navigation by default
+- Screen reader announcements for drag operations
+- Focus management handled automatically
+
+## Migration & Rollout
+
+**Database migration:**
+```typescript
+// drizzle/YYYY-MM-DD-add-frontpage-config.ts
+import { pgTable, jsonb } from 'drizzle-orm/pg-core'
+
+export async function up(db) {
+  await db.schema.alterTable('users').addColumn('frontpage_config', jsonb())
+}
+
+export async function down(db) {
+  await db.schema.alterTable('users').dropColumn('frontpage_config')
+}
+```
+
+**Backwards compatibility:**
+- Null config → use defaults (existing behavior)
+- No code changes for non-logged-in users
+- Guest users always see default layout
+
+**Handling new panels added in future:**
+
+When new panels are added to the codebase, users with saved configs won't see them automatically. Solution:
+
+```typescript
+// Merge saved config with current panel registry
+function mergeConfigWithDefaults(savedConfig: PanelConfig): PanelConfig {
+  const allPanelIds = Object.keys(PANEL_REGISTRY)
+  const savedPanelIds = savedConfig.panels.map(p => p.id)
+
+  // Find new panels not in saved config
+  const newPanels = allPanelIds.filter(id => !savedPanelIds.includes(id))
+
+  // Add new panels with defaults (visible, appended to their default column)
+  return {
+    panels: [
+      ...savedConfig.panels,
+      ...newPanels.map(id => ({
+        id,
+        visible: true,
+        order: getNextOrder(savedConfig, PANEL_METADATA[id].defaultColumn),
+        column: PANEL_METADATA[id].defaultColumn
+      }))
+    ]
+  }
+}
+```
+
+**Testing considerations:**
+- Test drag between columns
+- Test minimum visibility enforcement
+- Test mobile responsive (single column)
+- Test with missing/invalid config data
+- Test keyboard navigation
+
+**Rollout:**
+- Feature works immediately for all users
+- Existing users see current layout by default
+- Drag handles and hide buttons appear automatically for logged-in users
+
+## Summary
+
+This design enables full frontpage customization with drag-and-drop reordering, column movement, and panel visibility controls. The implementation leverages @dnd-kit for robust, accessible drag-and-drop, stores configuration in the database for cross-device sync, and maintains backwards compatibility with sensible defaults.


### PR DESCRIPTION
## Summary
- Added real-time live run panel showing logged-in user's active speedrun
- Panel appears at top of right column when user has active run
- Real-time updates via websocket, animated pulsing border
- Complete content: timer, splits, delta, progress bar
- Click-through to /live/{username} for full details

## Test Plan
- [ ] Log in and start a speedrun with LiveSplit
- [ ] Verify panel appears on frontpage with live updates
- [ ] Verify panel disappears when run ends
- [ ] Test click navigation to /live/{username}
- [ ] Verify styling in both light and dark modes
- [ ] Test responsive behavior on mobile
