### PR TITLE
Board rounds 2-5: mobile columns, cover accent, live strip, sidebar trust

### DIFF
--- a/app/(new-layout)/games-v2/[game]/game-page.module.scss
+++ b/app/(new-layout)/games-v2/[game]/game-page.module.scss
@@ -91,6 +91,10 @@
 // the cover's left edge rather than floating loose at the top of the page.
 .heroBack {
     margin-bottom: dt.$spacing-md;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: dt.$spacing-md;
 }
 
 .heroRow {

--- a/app/(new-layout)/games-v2/[game]/game-page.tsx
+++ b/app/(new-layout)/games-v2/[game]/game-page.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic';
 import { useEffect, useMemo, useState } from 'react';
 import Link from '~src/components/link';
 import { buildBoardHref } from '~src/lib/board-url';
+import type { GameModerator } from '../../../../types/board-claims.types';
 import type { ClaimCtaState } from './claim/claim-cta';
 import { BoardNavProvider, useBoardNavState } from './filters/use-board-nav';
 import styles from './game-page.module.scss';
@@ -27,9 +28,16 @@ interface Props {
     canManage: boolean;
     canManageRuns: boolean;
     claim?: ClaimCtaState | null;
+    moderators?: GameModerator[];
 }
 
-export function GamePage({ data, canManage, canManageRuns, claim }: Props) {
+export function GamePage({
+    data,
+    canManage,
+    canManageRuns,
+    claim,
+    moderators,
+}: Props) {
     const variableKeys = useMemo(
         () => data.variables.map((v) => v.nameNormalized),
         [data.variables],
@@ -202,6 +210,7 @@ export function GamePage({ data, canManage, canManageRuns, claim }: Props) {
                             yourRuns={data.yourRuns}
                             recentPbs={data.recentPbs}
                             claim={claim}
+                            moderators={moderators}
                             about={
                                 data.gameMeta.summaryOverride ??
                                 data.gameMeta.summary

--- a/app/(new-layout)/games-v2/[game]/game-page.tsx
+++ b/app/(new-layout)/games-v2/[game]/game-page.tsx
@@ -12,6 +12,7 @@ import { GameHero } from './header/game-hero';
 import mastheadStyles from './header/masthead.module.scss';
 import { formatSubcategoryKey, type LabelVariableDef } from './labels';
 import { LeaderboardPager } from './leaderboard/leaderboard-pager';
+import { LiveStrip } from './leaderboard/live-strip';
 import { RulesBody } from './rules/rules-panel';
 import { Sidebar } from './sidebar/sidebar';
 import type { GamePageData } from './types';
@@ -148,6 +149,10 @@ export function GamePage({ data, canManage, canManageRuns, claim }: Props) {
                         // regardless, so going inert is harmless.
                         inert={boardNav.isPending}
                     >
+                        <LiveStrip
+                            gameDisplay={data.game.display}
+                            categoryDisplay={data.selectedCategory.display}
+                        />
                         {data.invalidCombination ? (
                             <InvalidCombinationNotice
                                 gameSlug={data.game.name}

--- a/app/(new-layout)/games-v2/[game]/header/accent-from-cover.tsx
+++ b/app/(new-layout)/games-v2/[game]/header/accent-from-cover.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect } from 'react';
+import { computeAccent } from './accent-hue';
+
+const SAMPLE_W = 24;
+const SAMPLE_H = 32;
+
+interface Props {
+    coverUrl: string | null;
+    /** The element that receives the `--board-accent(-soft)` custom props. */
+    targetRef: React.RefObject<HTMLElement | null>;
+}
+
+/**
+ * Renders nothing; samples the cover into a tiny canvas and sets the plate's
+ * accent custom properties. Every failure path (no cover, load error,
+ * CORS-tainted canvas, monochrome art) is a silent no-op — the accentless
+ * plate is the designed fallback, not an error state.
+ */
+export function AccentFromCover({ coverUrl, targetRef }: Props) {
+    useEffect(() => {
+        if (!coverUrl) return;
+        const target = targetRef.current;
+        if (!target) return;
+        let cancelled = false;
+
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.decoding = 'async';
+        img.onload = () => {
+            if (cancelled) return;
+            try {
+                const canvas = document.createElement('canvas');
+                canvas.width = SAMPLE_W;
+                canvas.height = SAMPLE_H;
+                const ctx = canvas.getContext('2d');
+                if (!ctx) return;
+                ctx.drawImage(img, 0, 0, SAMPLE_W, SAMPLE_H);
+                const { data } = ctx.getImageData(0, 0, SAMPLE_W, SAMPLE_H);
+                const accent = computeAccent(data);
+                if (!accent) return;
+                target.style.setProperty(
+                    '--board-accent',
+                    `hsl(${accent.h} ${accent.s}% 45%)`,
+                );
+                target.style.setProperty(
+                    '--board-accent-soft',
+                    `hsl(${accent.h} ${accent.s}% 45% / 0.05)`,
+                );
+            } catch {
+                // Tainted canvas (no CORS on the image host) — keep the
+                // accentless look.
+            }
+        };
+        img.src = coverUrl;
+
+        return () => {
+            cancelled = true;
+            // Deliberately not removing already-applied props on unmount:
+            // the plate and this component unmount together.
+        };
+    }, [coverUrl, targetRef]);
+
+    return null;
+}

--- a/app/(new-layout)/games-v2/[game]/header/accent-hue.test.ts
+++ b/app/(new-layout)/games-v2/[game]/header/accent-hue.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { computeAccent } from './accent-hue';
+
+/** Builds an RGBA pixel array from repeated [r, g, b] triples. */
+function pixels(...rgb: [number, number, number][]): Uint8ClampedArray {
+    const out = new Uint8ClampedArray(rgb.length * 4);
+    rgb.forEach(([r, g, b], i) => {
+        out[i * 4] = r;
+        out[i * 4 + 1] = g;
+        out[i * 4 + 2] = b;
+        out[i * 4 + 3] = 255;
+    });
+    return out;
+}
+
+const RED: [number, number, number] = [200, 40, 40];
+const BLUE: [number, number, number] = [40, 60, 200];
+const GREY: [number, number, number] = [128, 128, 128];
+const WHITE: [number, number, number] = [250, 250, 250];
+const BLACK: [number, number, number] = [5, 5, 5];
+
+describe('computeAccent', () => {
+    it('finds the hue of a saturated single-color image', () => {
+        const accent = computeAccent(pixels(...Array(20).fill(RED)));
+        expect(accent).not.toBeNull();
+        // 200/40/40 is hue 0 ± the 30° bucket width
+        expect(accent!.h).toBeGreaterThanOrEqual(0);
+        expect(accent!.h).toBeLessThan(30);
+    });
+
+    it('returns null for a monochrome image', () => {
+        expect(computeAccent(pixels(...Array(10).fill(GREY)))).toBeNull();
+        expect(
+            computeAccent(
+                pixels(...Array(5).fill(WHITE), ...Array(5).fill(BLACK)),
+            ),
+        ).toBeNull();
+    });
+
+    it('picks the dominant hue bucket in a mixed image', () => {
+        const accent = computeAccent(
+            pixels(...Array(15).fill(BLUE), ...Array(5).fill(RED)),
+        );
+        expect(accent).not.toBeNull();
+        // 40/60/200 → hue ≈ 232
+        expect(accent!.h).toBeGreaterThan(200);
+        expect(accent!.h).toBeLessThan(260);
+    });
+
+    it('ignores near-white and near-black pixels when a color exists', () => {
+        const accent = computeAccent(
+            pixels(
+                ...Array(10).fill(WHITE),
+                ...Array(10).fill(BLACK),
+                ...Array(4).fill(RED),
+            ),
+        );
+        expect(accent).not.toBeNull();
+        expect(accent!.h).toBeLessThan(30);
+    });
+
+    it('clamps saturation into the tasteful band', () => {
+        const neon: [number, number, number] = [255, 0, 0]; // s = 100
+        const accent = computeAccent(pixels(...Array(10).fill(neon)));
+        expect(accent).not.toBeNull();
+        expect(accent!.s).toBeGreaterThanOrEqual(35);
+        expect(accent!.s).toBeLessThanOrEqual(70);
+    });
+
+    it('returns null when qualifying pixels are under the 8% floor', () => {
+        // 1 saturated pixel among 19 grey = 5%
+        expect(computeAccent(pixels(...Array(19).fill(GREY), RED))).toBeNull();
+    });
+});

--- a/app/(new-layout)/games-v2/[game]/header/accent-hue.ts
+++ b/app/(new-layout)/games-v2/[game]/header/accent-hue.ts
@@ -1,0 +1,70 @@
+export interface Accent {
+    /** Dominant hue in degrees [0, 360). */
+    h: number;
+    /** Saturation %, clamped to [35, 70] so no cover goes neon or muddy. */
+    s: number;
+}
+
+const BUCKET_DEG = 30;
+const MIN_SATURATION = 0.2; // below this a pixel reads as grey
+const MIN_LIGHTNESS = 0.12; // near-black carries no usable hue
+const MAX_LIGHTNESS = 0.92; // near-white likewise
+const MIN_QUALIFYING_RATIO = 0.08;
+
+/**
+ * Dominant-hue extraction for the board's cover-art accent. Input is a
+ * canvas `ImageData.data` array (RGBA). Returns null when the cover is
+ * effectively monochrome — callers fall back to the accentless look, which
+ * must remain identical to the pre-accent design.
+ */
+export function computeAccent(data: Uint8ClampedArray): Accent | null {
+    const buckets = new Map<number, { count: number; sats: number[] }>();
+    const totalPixels = Math.floor(data.length / 4);
+    if (totalPixels === 0) return null;
+
+    let qualifying = 0;
+    for (let i = 0; i < data.length; i += 4) {
+        const r = data[i] / 255;
+        const g = data[i + 1] / 255;
+        const b = data[i + 2] / 255;
+        const max = Math.max(r, g, b);
+        const min = Math.min(r, g, b);
+        const l = (max + min) / 2;
+        if (l < MIN_LIGHTNESS || l > MAX_LIGHTNESS) continue;
+        const delta = max - min;
+        if (delta === 0) continue;
+        const s = delta / (1 - Math.abs(2 * l - 1));
+        if (s < MIN_SATURATION) continue;
+
+        let h: number;
+        if (max === r) h = ((g - b) / delta + (g < b ? 6 : 0)) * 60;
+        else if (max === g) h = ((b - r) / delta + 2) * 60;
+        else h = ((r - g) / delta + 4) * 60;
+
+        qualifying++;
+        const bucket = Math.floor(h / BUCKET_DEG) * BUCKET_DEG;
+        const entry = buckets.get(bucket) ?? { count: 0, sats: [] };
+        entry.count++;
+        entry.sats.push(s);
+        buckets.set(bucket, entry);
+    }
+
+    if (qualifying / totalPixels < MIN_QUALIFYING_RATIO) return null;
+
+    let bestBucket = -1;
+    let bestCount = 0;
+    for (const [bucket, { count }] of buckets) {
+        if (count > bestCount) {
+            bestCount = count;
+            bestBucket = bucket;
+        }
+    }
+    if (bestBucket < 0) return null;
+
+    const sats = buckets.get(bestBucket)!.sats.sort((a, b) => a - b);
+    const medianS = sats[Math.floor(sats.length / 2)] * 100;
+    return {
+        h: bestBucket + BUCKET_DEG / 2,
+        s: Math.min(70, Math.max(35, Math.round(medianS))),
+    };
+}

--- a/app/(new-layout)/games-v2/[game]/header/board-masthead.tsx
+++ b/app/(new-layout)/games-v2/[game]/header/board-masthead.tsx
@@ -89,6 +89,11 @@ export function BoardMasthead({
                         canModerate={canManageRuns}
                         claim={claim}
                         back={back}
+                        standingsHref={
+                            data.categories.length > 1
+                                ? `/games-v2/${data.game.name}/standings`
+                                : undefined
+                        }
                     />
                     <div className={styles.boardLine}>
                         <div>

--- a/app/(new-layout)/games-v2/[game]/header/board-masthead.tsx
+++ b/app/(new-layout)/games-v2/[game]/header/board-masthead.tsx
@@ -7,6 +7,7 @@ import type { ClaimCtaState } from '../claim/claim-cta';
 import { FilterBar } from '../filters/filter-bar';
 import { RulesPanel } from '../rules/rules-panel';
 import type { GamePageData } from '../types';
+import { AccentFromCover } from './accent-from-cover';
 import { effectiveSubcategoryLabel } from './board-identity';
 import { CategoryRail } from './category-rail';
 import { GameHero } from './game-hero';
@@ -54,6 +55,8 @@ export function BoardMasthead({
     // the `inert` on `.railZone` below.
     const [stuck, setStuck] = useState(false);
     const sentinel = useRef<HTMLDivElement>(null);
+    // Accent target: AccentFromCover writes --board-accent(-soft) here.
+    const plateRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         const el = sentinel.current;
@@ -69,7 +72,11 @@ export function BoardMasthead({
 
     return (
         <>
-            <div className={styles.plate}>
+            <div className={styles.plate} ref={plateRef}>
+                <AccentFromCover
+                    coverUrl={data.gameMeta.coverUrl ?? data.game.image ?? null}
+                    targetRef={plateRef}
+                />
                 <div className={styles.plateTop}>
                     <GameHero
                         variant="condensed"

--- a/app/(new-layout)/games-v2/[game]/header/game-hero.tsx
+++ b/app/(new-layout)/games-v2/[game]/header/game-hero.tsx
@@ -37,6 +37,13 @@ interface Props {
      */
     back?: { href: string; label: string };
     /**
+     * Cross-category standings link, shown opposite the back link. Board
+     * pages pass it when the game has 2+ featured categories (same
+     * suppression rule as ViewTabs — single-category standings is just the
+     * board itself).
+     */
+    standingsHref?: string;
+    /**
      * `full` (default) is the spec-sheet hero the category wall and the
      * standings page use, where the game is the subject. `condensed` is for
      * a board page, where the game is context and the category below it is
@@ -55,6 +62,7 @@ export function GameHero({
     canModerate,
     claim,
     back,
+    standingsHref,
     variant = 'full',
 }: Props) {
     // Carries the current board context (category + subcategory) into the
@@ -104,9 +112,14 @@ export function GameHero({
                 variant === 'condensed' ? styles.heroCondensed : styles.hero
             }
         >
-            {back && (
+            {(back || standingsHref) && (
                 <div className={styles.heroBack}>
-                    <BackLink href={back.href} label={back.label} />
+                    {back && <BackLink href={back.href} label={back.label} />}
+                    {standingsHref && (
+                        <Link href={standingsHref} className={styles.quietLink}>
+                            Cross-category standings
+                        </Link>
+                    )}
                 </div>
             )}
             <div className={styles.heroRow}>

--- a/app/(new-layout)/games-v2/[game]/header/masthead.module.scss
+++ b/app/(new-layout)/games-v2/[game]/header/masthead.module.scss
@@ -107,10 +107,15 @@
     @include board.board-surface(0);
     overflow: hidden;
     margin-bottom: dt.$spacing-lg;
+    // Per-game identity: a flat 3px accent edge sampled from the cover art
+    // (AccentFromCover). Unset custom prop → transparent → today's look.
+    border-top: 3px solid var(--board-accent, transparent);
 }
 
 .plateTop {
     padding: 0 dt.$spacing-xl dt.$spacing-lg;
+    // Same accent one whisper down: a flat 5%-alpha tint, not a gradient.
+    background: var(--board-accent-soft, transparent);
 }
 
 .boardLine {

--- a/app/(new-layout)/games-v2/[game]/leaderboard/leaderboard-table.tsx
+++ b/app/(new-layout)/games-v2/[game]/leaderboard/leaderboard-table.tsx
@@ -142,7 +142,7 @@ export function LeaderboardTable({
                                 {secondary.label}
                             </th>
                         )}
-                        <th>When</th>
+                        <th className={styles.when}>When</th>
                         <th aria-label="Video, status and actions" />
                     </tr>
                 </thead>

--- a/app/(new-layout)/games-v2/[game]/leaderboard/leaderboard.module.scss
+++ b/app/(new-layout)/games-v2/[game]/leaderboard/leaderboard.module.scss
@@ -12,6 +12,12 @@
 
     tbody td {
         padding: dt.$spacing-md dt.$spacing-lg;
+
+        // Mobile: horizontal padding is the other thing eating the time
+        // column's room.
+        @media (max-width: 575.98px) {
+            padding-inline: dt.$spacing-sm;
+        }
     }
 
     tbody tr:last-child td {
@@ -43,10 +49,30 @@
     gap: dt.$spacing-sm;
     position: relative;
     z-index: 2;
+
+    @media (max-width: 575.98px) {
+        display: flex;
+        min-width: 0;
+
+        // Only the name shrinks — avatar, flag and WR chip hold their size.
+        a {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+    }
 }
 
 .when {
     white-space: nowrap;
+
+    // Mobile column priority: rank, runner and the time always fit; the
+    // date is the sacrifice (it stays in the row title attr and on the run
+    // detail page). Hiding th+td together keeps the table's column model
+    // consistent.
+    @media (max-width: 575.98px) {
+        display: none;
+    }
 }
 
 .trailing {
@@ -128,6 +154,15 @@ tr:focus-within .reveal {
 .runner {
     font-weight: 600;
     color: var(--bs-emphasis-color);
+
+    // Mobile: this cell absorbs all slack (max-width: 0 + width: 100% is
+    // the table-cell shrink trick) so the time cell keeps its intrinsic
+    // width — a long username ellipsizes instead of pushing the time off
+    // the right edge.
+    @media (max-width: 575.98px) {
+        max-width: 0;
+        width: 100%;
+    }
 }
 
 .time {

--- a/app/(new-layout)/games-v2/[game]/leaderboard/leaderboard.module.scss
+++ b/app/(new-layout)/games-v2/[game]/leaderboard/leaderboard.module.scss
@@ -382,6 +382,66 @@ tr:focus-within .reveal {
     }
 }
 
+// ---- Live strip ----------------------------------------------
+// Someone is running this exact board right now. `.liveDot`'s treatment is
+// replicated from sidebar.module.scss rather than composed across modules
+// (cross-module class composition depends on bundler concat order).
+.liveStrip {
+    display: flex;
+    align-items: center;
+    gap: dt.$spacing-sm;
+    padding: dt.$spacing-sm dt.$spacing-lg;
+    margin-block-end: dt.$spacing-sm;
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
+    border-radius: dt.$radius-lg;
+    font-size: dt.$font-size-sm;
+}
+
+.liveStripDot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: dt.$accent-red;
+    flex-shrink: 0;
+    animation: liveStripPulse 2s ease-in-out infinite;
+}
+
+@keyframes liveStripPulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.4;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .liveStripDot {
+        animation: none;
+    }
+}
+
+.liveStripText {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.liveStripLink {
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.liveStripMore {
+    @include board.control-pill;
+    margin-left: auto;
+    flex-shrink: 0;
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
+    padding: dt.$spacing-xs dt.$spacing-md;
+}
+
 // ---- Range indicator + Find me --------------------------------
 .boardMetaBar {
     display: flex;

--- a/app/(new-layout)/games-v2/[game]/leaderboard/live-strip.tsx
+++ b/app/(new-layout)/games-v2/[game]/leaderboard/live-strip.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useState } from 'react';
+import useSWR from 'swr';
+import type { LiveRun } from '~app/(new-layout)/live/live.types';
+import { fetcher } from '~src/utils/fetcher';
+import styles from './leaderboard.module.scss';
+import { RunnerAvatar } from './runner-avatar';
+
+const LiveDrawer = dynamic(
+    () => import('../drawers/live-drawer').then((m) => m.LiveDrawer),
+    { ssr: false },
+);
+
+interface Props {
+    gameDisplay: string;
+    categoryDisplay: string;
+}
+
+/**
+ * One-row strip above the table when someone is running THIS board's
+ * category right now — the live data speedrun.com structurally can't show.
+ * Shares LivePanel's SWR key, so it costs zero extra requests; renders
+ * nothing while loading, on error, or when no live run matches.
+ */
+export function LiveStrip({ gameDisplay, categoryDisplay }: Props) {
+    const [open, setOpen] = useState(false);
+    const { data } = useSWR<LiveRun[]>(
+        `/api/live?game=${encodeURIComponent(gameDisplay)}`,
+        fetcher,
+    );
+    const matches = (data ?? []).filter(
+        (r) =>
+            r.category &&
+            r.category.trim().toLowerCase() ===
+                categoryDisplay.trim().toLowerCase(),
+    );
+    if (matches.length === 0) return null;
+    const first = matches[0];
+    const others = matches.length - 1;
+
+    return (
+        <div className={styles.liveStrip}>
+            <span className={styles.liveStripDot} aria-hidden />
+            <RunnerAvatar name={first.user} picture={first.picture} size="xs" />
+            <span className={styles.liveStripText}>
+                <a
+                    href={first.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={styles.liveStripLink}
+                >
+                    {first.user}
+                </a>{' '}
+                is running {categoryDisplay} right now
+            </span>
+            {others > 0 && (
+                <button
+                    type="button"
+                    className={styles.liveStripMore}
+                    onClick={() => setOpen(true)}
+                >
+                    +{others} more live
+                </button>
+            )}
+            {open && (
+                <LiveDrawer
+                    show={open}
+                    onHide={() => setOpen(false)}
+                    gameDisplay={gameDisplay}
+                />
+            )}
+        </div>
+    );
+}

--- a/app/(new-layout)/games-v2/[game]/page.tsx
+++ b/app/(new-layout)/games-v2/[game]/page.tsx
@@ -60,15 +60,16 @@ export default async function GameV2Page({ params, searchParams }: PageProps) {
         caslSubject('leaderboard', { game: resolvedGame.name }),
     );
 
+    // Fetched unconditionally now: the sidebar's Moderators panel needs it
+    // on every board view, not just the claim-CTA path.
+    const moderators = await listGameModerators(resolvedGame.id);
+
     let claim: ClaimCtaState | null = null;
     if (sessionUsername && !canManage && !canManageRuns) {
-        const [mods, myClaim] = await Promise.all([
-            listGameModerators(resolvedGame.id),
-            getMyBoardClaim(session.id, resolvedGame.id),
-        ]);
+        const myClaim = await getMyBoardClaim(session.id, resolvedGame.id);
         claim = {
             gameId: resolvedGame.id,
-            hasModerators: mods.length > 0,
+            hasModerators: moderators.length > 0,
             myClaimPending: myClaim?.status === 'pending',
         };
     }
@@ -106,6 +107,7 @@ export default async function GameV2Page({ params, searchParams }: PageProps) {
             canManage={canManage}
             canManageRuns={canManageRuns}
             claim={claim}
+            moderators={moderators}
         />
     );
 }

--- a/app/(new-layout)/games-v2/[game]/sidebar/moderators-panel.tsx
+++ b/app/(new-layout)/games-v2/[game]/sidebar/moderators-panel.tsx
@@ -1,0 +1,41 @@
+import { UserLink } from '~src/components/links/links';
+import type { GameModerator } from '../../../../../types/board-claims.types';
+import styles from './sidebar.module.scss';
+
+const MAX_SHOWN = 8;
+
+/**
+ * Who runs this board — the trust signal speedrun.com carries at the foot
+ * of every leaderboard. Renders nothing on unmoderated games (the claim
+ * CTA covers that state).
+ */
+export function ModeratorsPanel({
+    moderators,
+}: {
+    moderators: GameModerator[];
+}) {
+    if (moderators.length === 0) return null;
+    const shown = moderators.slice(0, MAX_SHOWN);
+    const overflow = moderators.length - shown.length;
+
+    return (
+        <section className={styles.panel}>
+            <span className={`${styles.eyebrow} d-block mb-2`}>Moderators</span>
+            <ul className="list-unstyled mb-0">
+                {shown.map((m) => (
+                    <li key={m.assignmentId} className={styles.row}>
+                        <span className={styles.rowUser}>
+                            <UserLink username={m.username} url={undefined} />
+                        </span>
+                        {m.role === 'game-admin' && (
+                            <span className={styles.rowMeta}>admin</span>
+                        )}
+                    </li>
+                ))}
+            </ul>
+            {overflow > 0 && (
+                <p className={`${styles.rowMeta} mb-0`}>+{overflow} more</p>
+            )}
+        </section>
+    );
+}

--- a/app/(new-layout)/games-v2/[game]/sidebar/recent-pbs-panel.tsx
+++ b/app/(new-layout)/games-v2/[game]/sidebar/recent-pbs-panel.tsx
@@ -17,7 +17,7 @@ export function RecentPbsPanel({ pbs, gameSlug }: Props) {
         return (
             <section className={styles.panel}>
                 <span className={`${styles.eyebrow} d-block mb-2`}>
-                    Recent PBs
+                    Recent PBs · all boards
                 </span>
                 <p className="text-muted mb-0">No recent PBs.</p>
             </section>
@@ -26,7 +26,11 @@ export function RecentPbsPanel({ pbs, gameSlug }: Props) {
 
     return (
         <section className={styles.panel}>
-            <span className={`${styles.eyebrow} d-block mb-2`}>Recent PBs</span>
+            {/* "all boards": this panel is game-wide — without the scope the
+                16 Star entries beside a 120 Star board read as a bug. */}
+            <span className={`${styles.eyebrow} d-block mb-2`}>
+                Recent PBs · all boards
+            </span>
             <ul className="list-unstyled mb-0">
                 {pbs.slice(0, 5).map((p) => (
                     <li key={p.id} className={styles.pbRow}>

--- a/app/(new-layout)/games-v2/[game]/sidebar/sidebar.tsx
+++ b/app/(new-layout)/games-v2/[game]/sidebar/sidebar.tsx
@@ -1,3 +1,4 @@
+import type { GameModerator } from '../../../../../types/board-claims.types';
 import type {
     RecentPb,
     UserRanking,
@@ -5,6 +6,7 @@ import type {
 import { ClaimCta, type ClaimCtaState } from '../claim/claim-cta';
 import { AboutPanel } from './about-panel';
 import { LivePanel } from './live-panel';
+import { ModeratorsPanel } from './moderators-panel';
 import { RecentPbsPanel } from './recent-pbs-panel';
 import styles from './sidebar.module.scss';
 import { YourRunsPanel } from './your-runs-panel';
@@ -15,14 +17,23 @@ interface Props {
     recentPbs: RecentPb[];
     claim?: ClaimCtaState | null;
     about?: string | null;
+    moderators?: GameModerator[];
 }
 
-export function Sidebar({ game, yourRuns, recentPbs, claim, about }: Props) {
+export function Sidebar({
+    game,
+    yourRuns,
+    recentPbs,
+    claim,
+    about,
+    moderators,
+}: Props) {
     return (
         <>
             <LivePanel gameDisplay={game.display} />
             <YourRunsPanel rankings={yourRuns} gameSlug={game.name} />
             <RecentPbsPanel pbs={recentPbs} gameSlug={game.name} />
+            <ModeratorsPanel moderators={moderators ?? []} />
             <AboutPanel about={about ?? null} />
             {claim?.hasModerators && (
                 <div className={styles.sidebarFoot}>

--- a/docs/plans/2026-07-29-board-rounds-2-5-plan.md
+++ b/docs/plans/2026-07-29-board-rounds-2-5-plan.md
@@ -1,0 +1,139 @@
+# Board Rounds 2–5 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish the 2026-07-29 audit's remaining rounds on the games-v2 board: mobile column priority (R2), game-identity accent (R4), live-run strip (R5), and the three cheap backlog items (standings link, recent-PBs labeling, moderators panel).
+
+**Architecture:** All in `app/(new-layout)/games-v2/[game]/`. R2 is CSS-only column hiding at narrow widths. R4 is client-side dominant-hue extraction from the cover image (canvas, CORS-guarded, silent fallback to today's look) feeding one CSS custom property. R5 reuses LivePanel's SWR key so the strip costs zero extra requests. Moderators data rides the existing `listGameModerators` lib through page.tsx → Sidebar.
+
+**Tech Stack:** Next.js 16, React 19, SWR (already used by LivePanel), SCSS modules, vitest for pure logic.
+
+## Global Constraints
+
+- Never push to main; user merges. Branch: `worktree-board-rounds-2-5`.
+- Typecheck baseline 573 lines — gate on no growth.
+- No gradient washes; flat tints only. Accent must fall back to the current look when extraction fails.
+- Per-row pending pills stay dead (R1 decision).
+- Tests are pure .ts only (no TSX test infra); components verify via typecheck + static-render screenshots (gate-off-curl-revert recipe from R1, port 3001, kill server after).
+
+---
+
+### Task 1 (R2): Mobile column priority
+
+**Files:**
+- Modify: `leaderboard/leaderboard-table.tsx` (add `styles.when` to the When `<th>`)
+- Modify: `leaderboard/leaderboard.module.scss`
+
+**Change:** Below 576px the When column disappears (its data lives on the run detail page and in the row `title`); rank/runner/time/actions always fit. The runner name gets ellipsis so the time cell never clips.
+
+- [ ] Step 1: In `leaderboard-table.tsx` change `<th>When</th>` to `<th className={styles.when}>When</th>`.
+- [ ] Step 2: In `leaderboard.module.scss`:
+
+```scss
+@media (max-width: 575.98px) {
+    .when {
+        display: none;
+    }
+}
+
+.runnerCell {
+    // existing rules …
+    min-width: 0;
+
+    a {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+}
+
+.runner {
+    max-width: 0; // table-cell trick: cell shrinks to available space, name ellipsizes
+    width: 100%;
+}
+```
+
+(Exact selector layering decided against the rendered result — the invariant to verify on the 390px screenshot: full time string visible, no horizontal scroll.)
+
+- [ ] Step 3: Screenshot 390px, verify, commit `fix(board): mobile column priority — time always visible`.
+
+### Task 2 (R4): Cover-accent identity
+
+**Files:**
+- Create: `header/accent-from-cover.tsx` (client)
+- Create: `header/accent-hue.ts` + `header/accent-hue.test.ts` (pure: pixel array → accent hsl string or null)
+- Modify: `header/board-masthead.tsx`, `header/masthead.module.scss`
+
+**Contract:** `computeAccent(data: Uint8ClampedArray): { h: number; s: number } | null` — average hue of sufficiently-saturated, mid-lightness pixels; null when the cover is effectively monochrome (< 8% qualifying pixels). Component draws the cover into a 24×32 canvas (`crossOrigin='anonymous'`, try/catch — tainted canvas or load error → no-op) and sets `--board-accent: hsl(H S% 45%)` and `--board-accent-soft: hsl(H S% 45% / 0.05)` on the plate via a ref callback prop.
+
+**Paint (flat, no gradients):**
+
+```scss
+.plate {
+    // existing rules …
+    border-top: 3px solid var(--board-accent, transparent);
+}
+.plateTop {
+    background: var(--board-accent-soft, transparent);
+}
+```
+
+- [ ] Step 1: TDD `computeAccent` (cases: saturated red image → h≈0; grey image → null; mixed → dominant bucket). Hue via max-count 30° bucket, saturation = median of bucket members, clamp s to [35, 70].
+- [ ] Step 2: `AccentFromCover` component; mount inside `BoardMasthead`'s plate div; plate gets `ref`/`style` wiring.
+- [ ] Step 3: Screenshot light+dark; verify the bar reads as identity, not decoration; commit `feat(board): per-game accent from cover art`.
+
+### Task 3 (R5): Live-run strip above the table
+
+**Files:**
+- Create: `leaderboard/live-strip.tsx` (client)
+- Modify: `game-page.tsx` (render strip above `LeaderboardPager` inside `colMain`), `leaderboard/leaderboard.module.scss`
+
+**Contract:** Same SWR key as LivePanel (`/api/live?game=<display>` — SWR dedupes, zero extra requests). Filter `r.category` case-insensitive equal to the selected category display. Render nothing when no match, loading, or error. One row: live dot + "<user> is running <categoryDisplay> right now" (link to `r.url`) + "+N more" quiet button opening the existing `LiveDrawer` when N ≥ 1.
+
+```scss
+.liveStrip {
+    display: flex;
+    align-items: center;
+    gap: dt.$spacing-sm;
+    padding: dt.$spacing-sm dt.$spacing-lg;
+    margin-block-end: dt.$spacing-sm;
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
+    border-radius: dt.$radius-lg;
+    font-size: dt.$font-size-sm;
+}
+```
+
+Reuse `sidebar.module.scss`'s `.liveDot` treatment by replicating the class locally (cross-module composition is nondeterministic — R1 precedent).
+
+- [ ] Step 1: Build strip, wire into game-page (needs `gameDisplay` + `selectedCategory.display` — both on `data`).
+- [ ] Step 2: Typecheck; commit `feat(board): live-run strip when someone runs this board now`.
+
+### Task 4 (backlog): Standings link on board pages
+
+**Files:** `header/game-hero.tsx`, `game-page.tsx`, `game-page.module.scss`
+
+`GameHero` gains optional `standingsHref?: string`; rendered in `.heroBack` next to the back link as a quiet link "Cross-category standings". `game-page.tsx` passes it when `data.categories.length > 1` (mirrors ViewTabs' own suppression rule). `.heroBack` becomes a flex row with `justify-content: space-between`.
+
+- [ ] Implement, typecheck, commit `feat(board): standings reachable from any board`.
+
+### Task 5 (backlog): Recent-PBs scope label + moderators panel
+
+**Files:** `sidebar/recent-pbs-panel.tsx` (read first), `sidebar/about-panel.tsx` (read first), `sidebar/sidebar.tsx`, `page.tsx`, `sidebar/sidebar.module.scss`
+
+- Recent PBs: eyebrow becomes "Recent PBs · all boards" (aria-friendly plain text) — one-line change once the file is read.
+- Moderators: `page.tsx` already imports `listGameModerators`; fetch it unconditionally (it's the existing lib call, cached server-side), pass `moderators` (name list) through `GamePage` → `Sidebar`; new panel between RecentPbs and About: eyebrow "Moderators", `UserLink` per name, capped at 8 + "+N more" plain text. Empty list → panel not rendered.
+
+- [ ] Implement both, typecheck, commit `feat(board): moderators panel + recent-PBs scope label`.
+
+### Task 6: Verification + handoff
+
+- [ ] Full: vitest games-v2, tsc line-count vs 573, biome on `[game]`.
+- [ ] Screenshot pass (gate-off-curl-revert on port 3001; light/dark 1440×900 + 390px full; **kill the server by exact pid**).
+- [ ] Push `worktree-board-rounds-2-5`, open PR (user merges — gh pr merge is classifier-blocked).
+- [ ] Report with: what shipped per round, accent fallback behavior, live-strip match rule, sparkline/per-row stat hooks explicitly NOT built (needs backend per-runner attempt data — handoff).
+
+## Self-Review Notes
+
+- R5 "per-row stat hooks" from the audit is deliberately out: no per-runner attempt/history data on `LeaderboardEntry`; backend handoff documented in the final report instead of a half-fake hover.
+- Accent contrast: text never sits on the accent — it's a 3px bar and a 5% tint, so no WCAG risk; podium gold/silver/bronze and WR gold stay semantic and untouched.
+- LiveRun shape check needed at impl time (`user`, `login`, `url`, `picture`, `category` — from `~app/(new-layout)/live/live.types`).


### PR DESCRIPTION
Remaining rounds from the 2026-07-29 board audit (plan: docs/plans/2026-07-29-board-rounds-2-5-plan.md).

- **R2 mobile**: When column hidden <576px, runner names ellipsize, padding tightened — full times always visible at 390px (verified by screenshot)
- **R4 identity**: per-game accent sampled from cover art (flat 3px edge + 5% tint on the plate; silent fallback to the accentless look on CORS/monochrome). SM64 resolves to h=225 s=40 against the live IGDB cover
- **R5 live strip**: one-row strip above the table when a live run matches this board's category; reuses LivePanel's SWR key (zero extra requests)
- Standings quiet-link on board pages (2+ categories)
- Moderators sidebar panel (renders nothing when unmoderated); Recent PBs labeled "all boards"

Not built (needs backend): per-runner attempt counts / PB-progression hover — LeaderboardEntry has no per-runner history data.
