### PR TITLE
feat(games-v2): export full leaderboard as CSV/JSON

### DIFF
--- a/app/(new-layout)/games-v2/[game]/actions/export-board.action.ts
+++ b/app/(new-layout)/games-v2/[game]/actions/export-board.action.ts
@@ -1,0 +1,20 @@
+'use server';
+
+import {
+    getLeaderboardExport,
+    type LeaderboardQuery,
+} from '~src/lib/leaderboards-v1';
+import type { LeaderboardExportResponse } from '../../../../../types/leaderboards.types';
+
+// Public read — same visibility as the board itself; no auth gate. Returns
+// null on a vanished game/category/combination so the client can show a
+// retryable error instead of crashing the page.
+export async function exportLeaderboard(
+    q: Omit<LeaderboardQuery, 'page' | 'pageSize'>,
+): Promise<LeaderboardExportResponse | null> {
+    try {
+        return await getLeaderboardExport(q);
+    } catch {
+        return null;
+    }
+}

--- a/app/(new-layout)/games-v2/[game]/leaderboard/export-button.tsx
+++ b/app/(new-layout)/games-v2/[game]/leaderboard/export-button.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Download } from 'react-bootstrap-icons';
+import type { LeaderboardQuery } from '~src/lib/leaderboards-v1';
+import { exportLeaderboard } from '../actions/export-board.action';
+import gamePageStyles from '../game-page.module.scss';
+import mastheadStyles from '../header/masthead.module.scss';
+import { usePopoverFocus } from '../shared/use-popover-focus';
+import { buildLeaderboardCsv } from './export-csv';
+import styles from './leaderboard.module.scss';
+
+interface Props {
+    /** Same filter state the pager fetches with — page/pageSize are ignored. */
+    query: Omit<LeaderboardQuery, 'page'>;
+    gameSlug: string;
+    categorySlug: string;
+    subcategoryKey: string;
+    showMilliseconds: boolean;
+}
+
+type Format = 'csv' | 'json';
+
+/**
+ * "Export" popover on the board meta bar: downloads the entire board —
+ * unpaginated, with the enrichment fields (variables, platform, origin,
+ * verification timestamps, ...) the paginated endpoint doesn't carry —
+ * as CSV or JSON, honoring the active filters.
+ */
+export function ExportButton({
+    query,
+    gameSlug,
+    categorySlug,
+    subcategoryKey,
+    showMilliseconds,
+}: Props) {
+    const [open, setOpen] = useState(false);
+    const [busy, setBusy] = useState<Format | null>(null);
+    const [note, setNote] = useState<'error' | 'truncated' | null>(null);
+    const rootRef = useRef<HTMLDivElement>(null);
+    const panelRef = useRef<HTMLDivElement>(null);
+
+    const close = () => setOpen(false);
+    usePopoverFocus({ open, onClose: close, panelRef });
+
+    useEffect(() => {
+        if (!open) return;
+        const onDown = (e: MouseEvent) => {
+            if (!rootRef.current?.contains(e.target as Node)) close();
+        };
+        document.addEventListener('mousedown', onDown);
+        return () => document.removeEventListener('mousedown', onDown);
+    }, [open]);
+
+    const download = (content: string, filename: string, mime: string) => {
+        const url = URL.createObjectURL(new Blob([content], { type: mime }));
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        link.click();
+        URL.revokeObjectURL(url);
+    };
+
+    const runExport = async (format: Format) => {
+        if (busy) return;
+        setBusy(format);
+        setNote(null);
+        try {
+            const { pageSize: _pageSize, ...rest } = query;
+            const res = await exportLeaderboard(rest);
+            if (!res) {
+                setNote('error');
+                return;
+            }
+            const slice = [gameSlug, categorySlug, subcategoryKey]
+                .filter(Boolean)
+                .join('-');
+            const stamp = res.exportedAt.slice(0, 10);
+            if (format === 'csv') {
+                download(
+                    buildLeaderboardCsv(res, showMilliseconds),
+                    `${slice}-leaderboard-${stamp}.csv`,
+                    'text/csv;charset=utf-8',
+                );
+            } else {
+                download(
+                    JSON.stringify(res, null, 2),
+                    `${slice}-leaderboard-${stamp}.json`,
+                    'application/json',
+                );
+            }
+            if (res.truncated) {
+                setNote('truncated');
+            } else {
+                close();
+            }
+        } finally {
+            setBusy(null);
+        }
+    };
+
+    return (
+        <div className={gamePageStyles.popoverRoot} ref={rootRef}>
+            <button
+                type="button"
+                className={mastheadStyles.chip}
+                aria-haspopup="dialog"
+                aria-expanded={open}
+                onClick={() => setOpen((o) => !o)}
+            >
+                <Download size={13} aria-hidden />
+                Export
+            </button>
+            {open && (
+                <div
+                    ref={panelRef}
+                    className={gamePageStyles.popoverPanel}
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label="Export leaderboard"
+                >
+                    <div className={styles.exportMenu}>
+                        <button
+                            type="button"
+                            className={styles.findMeBtn}
+                            disabled={busy !== null}
+                            onClick={() => runExport('csv')}
+                        >
+                            {busy === 'csv' ? 'Exporting…' : 'Download CSV'}
+                        </button>
+                        <button
+                            type="button"
+                            className={styles.findMeBtn}
+                            disabled={busy !== null}
+                            onClick={() => runExport('json')}
+                        >
+                            {busy === 'json' ? 'Exporting…' : 'Download JSON'}
+                        </button>
+                        {note === 'error' && (
+                            <span className={styles.exportNote}>
+                                Export failed. Try again.
+                            </span>
+                        )}
+                        {note === 'truncated' && (
+                            <span className={styles.exportNote}>
+                                Board is larger than the export limit — the file
+                                holds the top of the board only.
+                            </span>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/app/(new-layout)/games-v2/[game]/leaderboard/export-csv.ts
+++ b/app/(new-layout)/games-v2/[game]/leaderboard/export-csv.ts
@@ -1,0 +1,70 @@
+import { getFormattedString } from '~src/components/util/datetime';
+import type {
+    LeaderboardExportEntry,
+    LeaderboardExportResponse,
+} from '../../../../../types/leaderboards.types';
+
+// Base columns in spreadsheet-friendly order; per-run variables append as
+// one `variable:<key>` column per key found anywhere on the board.
+const BASE_COLUMNS: {
+    header: string;
+    value: (
+        e: LeaderboardExportEntry,
+        fmt: (ms: number | null) => string,
+    ) => unknown;
+}[] = [
+    { header: 'rank', value: (e) => e.rank },
+    { header: 'runner', value: (e) => e.runnerName },
+    { header: 'country', value: (e) => e.country },
+    { header: 'time', value: (e, fmt) => fmt(e.time) },
+    { header: 'time_ms', value: (e) => e.time },
+    { header: 'real_time', value: (e, fmt) => fmt(e.realTime) },
+    { header: 'real_time_ms', value: (e) => e.realTime },
+    { header: 'game_time', value: (e, fmt) => fmt(e.gameTime) },
+    { header: 'game_time_ms', value: (e) => e.gameTime },
+    { header: 'run_date', value: (e) => e.runDate },
+    { header: 'verification_status', value: (e) => e.verificationStatus },
+    { header: 'verified_at', value: (e) => e.verifiedAt },
+    { header: 'vod_url', value: (e) => e.vodUrl },
+    { header: 'source', value: (e) => e.source ?? 'run' },
+    { header: 'origin', value: (e) => e.origin },
+    { header: 'subcategory_key', value: (e) => e.subcategoryKey },
+    { header: 'platform', value: (e) => e.platform },
+    { header: 'emulator', value: (e) => e.emulator },
+    { header: 'speedrun_run_id', value: (e) => e.speedrunRunId },
+    { header: 'ingested_at', value: (e) => e.ingestedAt },
+    { header: 'run_id', value: (e) => e.runId },
+    { header: 'manual_time_id', value: (e) => e.manualTimeId },
+    { header: 'user_id', value: (e) => e.userId },
+    { header: 'is_guest', value: (e) => e.isGuest },
+];
+
+const escapeCell = (value: unknown): string => {
+    if (value === null || value === undefined) return '';
+    const s = String(value);
+    return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+};
+
+export function buildLeaderboardCsv(
+    res: LeaderboardExportResponse,
+    showMilliseconds: boolean,
+): string {
+    const fmt = (ms: number | null): string =>
+        ms === null
+            ? ''
+            : getFormattedString(String(ms), showMilliseconds, false, false);
+
+    const variableKeys = [
+        ...new Set(res.entries.flatMap((e) => Object.keys(e.variables ?? {}))),
+    ].sort();
+
+    const header = [
+        ...BASE_COLUMNS.map((c) => c.header),
+        ...variableKeys.map((k) => `variable:${k}`),
+    ];
+    const rows = res.entries.map((e) => [
+        ...BASE_COLUMNS.map((c) => escapeCell(c.value(e, fmt))),
+        ...variableKeys.map((k) => escapeCell(e.variables?.[k])),
+    ]);
+    return [header.map(escapeCell), ...rows].map((r) => r.join(',')).join('\n');
+}

--- a/app/(new-layout)/games-v2/[game]/leaderboard/leaderboard-pager.tsx
+++ b/app/(new-layout)/games-v2/[game]/leaderboard/leaderboard-pager.tsx
@@ -12,6 +12,7 @@ import { FiltersPopover } from '../filters/filters-popover';
 import { VerifiedToggle } from '../filters/verified-toggle';
 import { isSameRunner } from '../shared/is-same-runner';
 import { computeBoardRange } from './board-range';
+import { ExportButton } from './export-button';
 import { planFindMeSearch } from './find-me-plan';
 import styles from './leaderboard.module.scss';
 import { YOU_ROW_ID } from './leaderboard-row';
@@ -369,6 +370,13 @@ export function LeaderboardPager({
                             </button>
                         )}
                         <VerifiedToggle verified={query.verified ?? false} />
+                        <ExportButton
+                            query={query}
+                            gameSlug={gameSlug}
+                            categorySlug={categorySlug}
+                            subcategoryKey={subcategoryKey}
+                            showMilliseconds={showMilliseconds}
+                        />
                         <FiltersPopover
                             defs={variableDefs}
                             selectedVarFilters={selectedVarFilters}

--- a/app/(new-layout)/games-v2/[game]/leaderboard/leaderboard.module.scss
+++ b/app/(new-layout)/games-v2/[game]/leaderboard/leaderboard.module.scss
@@ -493,6 +493,20 @@ tr:focus-within .reveal {
     }
 }
 
+.exportMenu {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: dt.$spacing-sm;
+    min-width: 11rem;
+}
+
+.exportNote {
+    font-size: dt.$font-size-xs;
+    color: var(--bs-secondary-color);
+    max-width: 14rem;
+}
+
 .pendingNote {
     font-size: dt.$font-size-xs;
     color: var(--bs-tertiary-color);

--- a/docs/frontend-guide-leaderboard-export.md
+++ b/docs/frontend-guide-leaderboard-export.md
@@ -1,0 +1,76 @@
+# Frontend guide: full-board leaderboard export
+
+Backend copy is authoritative; `therun-fr/docs/` holds a copy.
+
+## Endpoint
+
+```
+GET https://api.therun.gg/mod/v1/leaderboards/{game}/{category}/export
+```
+
+- **`/mod` base path is required.** The main API Gateway is at its 500-resource
+  hard cap, so this route is only reachable through the moderation proxy API
+  (`proxy: true`, strips the `mod` prefix before the Lambda). Handler:
+  `src/api/leaderboards/export-handler.ts`, dispatched from
+  `handleLeaderboards` via `isExportPath`.
+- Public, no auth — same visibility as the paginated board endpoint.
+- Query params: identical to the board endpoint (`timing`, `combined`,
+  subcategory/filter variables by `nameNormalized`, `verified`, `year`).
+  `page`/`pageSize` are ignored.
+- Not enveloped: the body is the object below directly (no `{ result }`).
+
+## Response
+
+```jsonc
+{
+  "game": { "id": 1, "slug": "hades", "display": "Hades" },
+  "category": { "id": 2, "slug": "any-heat", "display": "Any% Heat" },
+  "timing": "rt",              // resolved, like the board endpoint
+  "defaultTiming": "rt",
+  "forceRealTime": false,
+  "hideRealTime": false,
+  "hideGameTime": false,
+  "totalItems": 312,
+  "truncated": false,           // true when the 10 000-row guard fired
+  "exportedAt": "2026-08-01T12:00:00.000Z",
+  "entries": [ /* LeaderboardExportEntry[] — full board, rank order */ ]
+}
+```
+
+`LeaderboardExportEntry` = the paginated board's `LeaderboardEntry`
+(rank, runnerName, userId, isGuest, time/realTime/gameTime, runDate,
+vodUrl, verificationStatus, source, manualTimeId, picture, country) plus:
+
+| Field | Type | Notes |
+|---|---|---|
+| `subcategoryKey` | `string \| null` | the entry's own slice |
+| `variables` | `Record<string,string> \| null` | per-run variables (runs only) |
+| `platform` | `string \| null` | runs only |
+| `emulator` | `boolean \| null` | runs only |
+| `speedrunRunId` | `string \| null` | set when timer-synced |
+| `verifiedAt` | `string \| null` | ISO timestamp |
+| `ingestedAt` | `string \| null` | ISO timestamp (`created_at`) |
+| `origin` | `string \| null` | `timer \| guest_submit \| submission \| manual_mod \| manual_self` |
+
+All emitted fields are already public via the board or run-detail endpoints;
+runner names/pictures/countries go through the same anonymization mask.
+Mod-only fields (modNote, rejectionReason, manual-time reason/createdBy)
+are deliberately excluded.
+
+## Limits
+
+- `EXPORT_MAX_ROWS = 10000` (same pattern as game standings' `MAX_RUNNERS`).
+  When a board exceeds it, `entries` holds the top 10 000 and
+  `truncated: true` is set — surface this to the user.
+- Enrichment lookups are chunked (1 000 ids per query).
+
+## Frontend integration (implemented)
+
+- Types: `LeaderboardExportEntry` / `LeaderboardExportResponse` in
+  `therun-fr/types/leaderboards.types.ts`.
+- Fetcher: `getLeaderboardExport` in `therun-fr/src/lib/leaderboards-v1.ts` —
+  deliberately uncached.
+- UI: `ExportButton` on the games-v2 board meta bar
+  (`app/(new-layout)/games-v2/[game]/leaderboard/export-button.tsx`),
+  CSV via `export-csv.ts` (variables become `variable:<key>` columns) or raw
+  JSON, honoring the active filter state.

--- a/scripts/check-scss.mjs
+++ b/scripts/check-scss.mjs
@@ -30,7 +30,11 @@ const files = findScssModules(ROOT);
 let failed = 0;
 for (const f of files) {
     try {
-        execFileSync('npx', ['sass', '--no-source-map', '--style=compressed', f, '/dev/null'], { stdio: 'pipe' });
+        execFileSync(
+            'npx',
+            ['sass', '--no-source-map', '--style=compressed', f, '/dev/null'],
+            { stdio: 'pipe' },
+        );
     } catch (e) {
         failed++;
         console.error(`FAIL ${f}\n${e.stderr}`);

--- a/src/lib/leaderboards-v1.ts
+++ b/src/lib/leaderboards-v1.ts
@@ -2,6 +2,7 @@
 
 import { cacheLife, cacheTag } from 'next/cache';
 import type {
+    LeaderboardExportResponse,
     LeaderboardResponse,
     ManualTimeDetail,
     RunDetail,
@@ -124,6 +125,27 @@ export async function getLeaderboard(
                 };
             }
         }
+        throw e;
+    }
+}
+
+/**
+ * Full-board export: unpaginated, with the per-run enrichment fields the
+ * paginated endpoint omits. Deliberately uncached — an export should reflect
+ * the board as it is right now. Rides the `/mod` base-path mapping like
+ * getUserRankingsByName (the main gateway is at its 500-resource cap, so
+ * the export route only exists via the proxy API).
+ */
+export async function getLeaderboardExport(
+    q: Omit<LeaderboardQuery, 'page' | 'pageSize'>,
+): Promise<LeaderboardExportResponse | null> {
+    const game = encodeURIComponent(q.gameSlug);
+    const category = encodeURIComponent(q.categorySlug);
+    const path = `/mod/v1/leaderboards/${game}/${category}/export?${buildLeaderboardQS(q)}`;
+    try {
+        return await v1Fetch<LeaderboardExportResponse>(path);
+    } catch (e) {
+        if (e instanceof V1FetchError && e.status === 404) return null;
         throw e;
     }
 }

--- a/types/leaderboards.types.ts
+++ b/types/leaderboards.types.ts
@@ -162,6 +162,36 @@ export interface LeaderboardResponse {
     hideGameTime: boolean;
 }
 
+// Backend: GET /mod/v1/leaderboards/{game}/{category}/export — the whole
+// board in one response plus per-run fields the paginated endpoint doesn't
+// carry. Rides the /mod base path (main gateway is at its resource cap).
+export interface LeaderboardExportEntry extends LeaderboardEntry {
+    subcategoryKey: string | null;
+    platform: string | null;
+    emulator: boolean | null;
+    /** speedrun.com-linked run reference, when the run was timer-synced. */
+    speedrunRunId: string | null;
+    verifiedAt: string | null;
+    ingestedAt: string | null;
+    /** How the entry got here: timer | guest_submit | submission | manual_mod | manual_self. */
+    origin: string | null;
+}
+
+export interface LeaderboardExportResponse {
+    game: { id: number; slug: string; display: string };
+    category: { id: number; slug: string; display: string };
+    timing: 'rt' | 'gt';
+    defaultTiming: 'rt' | 'gt';
+    forceRealTime: boolean;
+    hideRealTime: boolean;
+    hideGameTime: boolean;
+    totalItems: number;
+    /** True when the backend's row guard fired and entries < totalItems. */
+    truncated: boolean;
+    exportedAt: string;
+    entries: LeaderboardExportEntry[];
+}
+
 export interface WrHistoryEntry {
     runnerName: string;
     time: number;


### PR DESCRIPTION
Adds an **Export** popover to the games-v2 board meta bar (next to Verified/Filters) that downloads the entire leaderboard — unpaginated, honoring the active category/subcategory/variable/verified filter state — as **CSV** or **JSON**.

Backed by the new backend endpoint `GET /mod/v1/leaderboards/{game}/{category}/export` (therun-backend 4cdfa13), which returns the full board plus per-run fields the paginated endpoint omits: per-run `variables`, `subcategoryKey`, `platform`, `emulator`, `speedrunRunId`, `verifiedAt`, `ingestedAt`, `origin`. Contract doc: `docs/frontend-guide-leaderboard-export.md` (copied from the backend repo, backend copy authoritative).

- CSV flattens variables into `variable:<key>` columns; times come as both formatted and raw ms columns.
- JSON download is the raw export response.
- The backend caps exports at 10 000 rows (standings-style guard); when it fires, the popover shows a note that the file only holds the top of the board.
- Export fetch is deliberately uncached so files reflect the live board.
