### PR TITLE
fix(run page): tolerate numeric variable values from LiveSplit splits

### DIFF
--- a/app/(new-layout)/games-v2/[game]/labels.test.ts
+++ b/app/(new-layout)/games-v2/[game]/labels.test.ts
@@ -133,6 +133,19 @@ describe('formatVariableList', () => {
         expect(formatVariableList({ platform: 'pc' }, defs)).toBe('PC');
     });
 
+    it('survives non-string values harvested from LiveSplit splits', () => {
+        // Real payloads: { Version: 5 }, { Patch: 1.14 } — numbers, not
+        // strings, despite the declared type. This used to throw
+        // `a.replace is not a function` and 500 the run page.
+        const vars = {
+            Version: 5,
+            Patch: 1.14,
+            Platforms: 'PC',
+            Skipped: null,
+        } as unknown as Record<string, string>;
+        expect(formatVariableList(vars)).toBe('Version 5 · Patch 1.14 · PC');
+    });
+
     it('never leaves a raw key=value pair in the output', () => {
         const result = formatVariableList({ console: 'n64', region: 'ntsc' });
         expect(result).not.toContain('=');

--- a/app/(new-layout)/games-v2/[game]/labels.ts
+++ b/app/(new-layout)/games-v2/[game]/labels.ts
@@ -27,8 +27,11 @@ const GAME_TIME_KEYS = new Set(['gt', 'gametime', 'igt', 'lrt']);
  * fixing anything for the latter.
  */
 export function splitHumanizedWords(raw: string): string {
-    if (!raw) return '';
-    return raw
+    if (raw === null || raw === undefined || raw === '') return '';
+    // Variable values harvested from LiveSplit arrive as whatever JSON the
+    // splits file held — `"Version": 5`, `"Patch": 1.14` — even though the
+    // type says string. Coerce instead of crashing the run page on `.replace`.
+    return String(raw)
         .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
         .replace(/[_-]+/g, ' ')
         .trim();
@@ -118,9 +121,11 @@ export function formatVariableList(
     vars: Record<string, string>,
     defs?: LabelVariableDef[],
 ): string {
-    const entries = Object.entries(vars).filter(([k]) => k.length > 0);
+    const entries = Object.entries(vars).filter(
+        ([k, v]) => k.length > 0 && v !== null && v !== undefined,
+    );
     if (entries.length === 0) return '';
-    return entries.map(([k, v]) => formatPair(k, v, defs)).join(' · ');
+    return entries.map(([k, v]) => formatPair(k, String(v), defs)).join(' · ');
 }
 
 /**


### PR DESCRIPTION
Vercel has been logging `TypeError: a.replace is not a function` on `/games-v2/{game}/run/{id}` (~2–20/hr since today). Cause: `/v1/leaderboards/runs/{id}` returns `variables` with numeric values for runs harvested from splits files (`{ Version: 5 }`, `{ Patch: 1.14 }` — e.g. runs 2098543, 2133170, 2117996) while the frontend type says `Record<string,string>`; `formatVariableList → humanizeWord` called `.replace` on a number and the page 500'd.

Fix: `splitHumanizedWords` coerces with `String()`, `formatVariableList` skips null/undefined and stringifies values. Regression test added.

Backend follow-up worth doing separately: normalise variable values to strings when harvesting splits.