### PR TITLE
Fix the mobile menu height within Safari

### DIFF
--- a/src/components/Topbar/MobileMenu.module.scss
+++ b/src/components/Topbar/MobileMenu.module.scss
@@ -60,6 +60,7 @@
     backdrop-filter: blur(24px);
     -webkit-backdrop-filter: blur(24px);
     padding: 0;
+    height: 100vh;
     // NOTE: do not add `overflow` here. iOS Safari fails to paint the
     // descendant content of an element that has both -webkit-backdrop-filter
     // and a scroll container, leaving only the first child (.header) visible.


### PR DESCRIPTION
### Description

The mobile menu within safari doesn't render properly due to positioning shenanigans and `display: flex`. Can be reproduced on the latest Safari on MacOS Tahoe:

<img width="381" height="451" alt="Bildschirmfoto 2026-08-22 um 01 10 57" src="https://github.com/user-attachments/assets/13dd661e-d9a7-4080-8e86-10f509fb509b" />

Setting it to 100vh fixes it for WebKit browsers (Safari). Will not affect anything on Blink and Gecko as well 
<img width="474" height="1018" alt="Bildschirmfoto 2026-08-22 um 01 11 07" src="https://github.com/user-attachments/assets/23efec9e-31f9-4f27-bf13-ba9e6c2b1bd5" />
