### PR TITLE
SRC import: moderator commit-flags toggle panel

### DIFF
--- a/app/(new-layout)/games-v2/[game]/manage/src-import/commit-panel.test.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/src-import/commit-panel.test.tsx
@@ -22,6 +22,7 @@ vi.mock('./src-import-actions', () => ({
     setSrcOnlyAction: vi.fn(async () => ({
         result: { jobId: 7, srcOnlyLeaderboard: true },
     })),
+    setFlagsAction: vi.fn(async () => ({ result: {} })),
     getSrcImportPlanAction: vi.fn(async () => ({ result: emptyPlan() })),
 }));
 
@@ -32,6 +33,7 @@ import {
     importRunsAction,
     reconcileAction,
     reconcileUndoAction,
+    setFlagsAction,
     undoRunsAction,
 } from './src-import-actions';
 
@@ -82,6 +84,9 @@ const job = (over: Partial<SrcImportJob> = {}): SrcImportJob => ({
     configAppliedAt: null,
     runsImportedAt: null,
     srcOnlyLeaderboard: false,
+    kind: 'manual',
+    changeSummary: null,
+    commitFlags: null,
     ...over,
 });
 
@@ -98,6 +103,36 @@ describe('CommitPanel', () => {
         expect(
             screen.getByRole('button', { name: /apply config/i }),
         ).toBeEnabled();
+    });
+
+    it('shows the Import options panel in the plan stage, defaulting all on', () => {
+        render(<CommitPanel job={job()} {...props} />);
+        expect(screen.getByText(/import options/i)).toBeInTheDocument();
+        expect(
+            screen.getByRole('checkbox', { name: /import guest runs/i }),
+        ).toBeChecked();
+    });
+
+    it('persists a flag toggle via setFlagsAction with only the changed key', async () => {
+        render(<CommitPanel job={job()} {...props} />);
+        fireEvent.click(
+            screen.getByRole('checkbox', { name: /import guest runs/i }),
+        );
+        await waitFor(() => {
+            expect(setFlagsAction).toHaveBeenCalledWith({
+                gameId: 12,
+                gameSlug: 'sm64',
+                jobId: 7,
+                flags: { importGuests: false },
+            });
+        });
+    });
+
+    it('hides the Import options panel once config is applied', () => {
+        render(
+            <CommitPanel job={job({ commitStatus: 'applied' })} {...props} />,
+        );
+        expect(screen.queryByText(/import options/i)).not.toBeInTheDocument();
     });
 
     it('calls applyConfigAction and onChanged on Apply config', async () => {

--- a/app/(new-layout)/games-v2/[game]/manage/src-import/commit-panel.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/src-import/commit-panel.tsx
@@ -3,10 +3,12 @@
 import { useEffect, useRef, useState, useTransition } from 'react';
 import type {
     SrcCommitPlan,
+    SrcImportCommitFlags,
     SrcImportJob,
 } from '../../../../../../types/src-import.types';
 import { InlineError } from '../shared/form-kit';
 import kit from '../shared/form-kit.module.scss';
+import { ImportOptions, resolveCommitFlags } from './import-options';
 import { PlanPreview, planHasConflicts } from './plan-preview';
 import styles from './src-import.module.scss';
 import {
@@ -15,6 +17,7 @@ import {
     importRunsAction,
     reconcileAction,
     reconcileUndoAction,
+    setFlagsAction,
     setSrcOnlyAction,
     undoConfigAction,
     undoRunsAction,
@@ -272,6 +275,9 @@ export function CommitPanel({ job, gameId, gameSlug, onChanged }: Props) {
     const [pending, startTransition] = useTransition();
     const [actionError, setActionError] = useState<string | null>(null);
     const [srcOnly, setSrcOnly] = useState(job.srcOnlyLeaderboard);
+    const [flags, setFlagsState] = useState(
+        resolveCommitFlags(job.commitFlags),
+    );
     const [plan, setPlan] = useState<SrcCommitPlan | null>(null);
     const [reconcileError, setReconcileError] = useState<string | null>(null);
     // Whether the one-shot AUTO reconcile has fired for the current job this
@@ -354,6 +360,26 @@ export function CommitPanel({ job, gameId, gameSlug, onChanged }: Props) {
         });
     };
 
+    const onFlagsChange = (patch: SrcImportCommitFlags) => {
+        // Optimistic: reflect the toggle immediately, then persist the patch.
+        // The backend patch-merges, so we only ever send the changed key(s).
+        setFlagsState((prev) => ({ ...prev, ...patch }));
+        setActionError(null);
+        startTransition(async () => {
+            const res = await setFlagsAction({
+                gameId,
+                gameSlug,
+                jobId: job.id,
+                flags: patch,
+            });
+            if ('error' in res) {
+                setActionError(res.error);
+                return;
+            }
+            await onChanged();
+        });
+    };
+
     const hasConflicts = plan !== null && planHasConflicts(plan);
     const applyBlockedByConflicts =
         vm.primary?.action === 'apply-config' && hasConflicts;
@@ -423,6 +449,17 @@ export function CommitPanel({ job, gameId, gameSlug, onChanged }: Props) {
                         reconciling the board will start automatically.
                     </p>
                 ))}
+
+            {/* Import options are consumed at apply-config, so they are only
+                offered while the plan is still being reviewed (before the first
+                commit step). The backend also freezes them once importing. */}
+            {vm.primary?.action === 'apply-config' && (
+                <ImportOptions
+                    flags={flags}
+                    disabled={pending}
+                    onChange={onFlagsChange}
+                />
+            )}
 
             {vm.errorMessage && <InlineError>{vm.errorMessage}</InlineError>}
             {actionError && <InlineError>{actionError}</InlineError>}

--- a/app/(new-layout)/games-v2/[game]/manage/src-import/import-options.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/src-import/import-options.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import type { SrcImportCommitFlags } from '../../../../../../types/src-import.types';
+import styles from './src-import.module.scss';
+
+export type ResolvedCommitFlags = Required<SrcImportCommitFlags>;
+
+const DEFAULT_FLAGS: ResolvedCommitFlags = {
+    importTheme: true,
+    themeMode: 'overwrite',
+    importMiscCategories: true,
+    importLevelCategories: true,
+    importPending: true,
+    importGuests: true,
+    setMinTimeFloor: true,
+};
+
+/**
+ * Fills every unset flag with its behavior-preserving default — mirrors the
+ * backend resolveCommitFlags so the panel shows the effective state even when
+ * the job has no commitFlags yet.
+ */
+export function resolveCommitFlags(
+    flags: SrcImportCommitFlags | null | undefined,
+): ResolvedCommitFlags {
+    return {
+        importTheme: flags?.importTheme ?? DEFAULT_FLAGS.importTheme,
+        themeMode: flags?.themeMode ?? DEFAULT_FLAGS.themeMode,
+        importMiscCategories:
+            flags?.importMiscCategories ?? DEFAULT_FLAGS.importMiscCategories,
+        importLevelCategories:
+            flags?.importLevelCategories ?? DEFAULT_FLAGS.importLevelCategories,
+        importPending: flags?.importPending ?? DEFAULT_FLAGS.importPending,
+        importGuests: flags?.importGuests ?? DEFAULT_FLAGS.importGuests,
+        setMinTimeFloor:
+            flags?.setMinTimeFloor ?? DEFAULT_FLAGS.setMinTimeFloor,
+    };
+}
+
+type ToggleKey = Exclude<keyof SrcImportCommitFlags, 'themeMode'>;
+
+const TOGGLES: Array<{ key: ToggleKey; label: string; hint: string }> = [
+    {
+        key: 'importTheme',
+        label: 'Import board theme',
+        hint: 'Apply the speedrun.com board colors and background to this game.',
+    },
+    {
+        key: 'importMiscCategories',
+        label: 'Import miscellaneous categories',
+        hint: 'speedrun.com “misc” categories, grouped under Miscellaneous.',
+    },
+    {
+        key: 'importLevelCategories',
+        label: 'Import individual-level categories',
+        hint: 'Per-level (IL) categories and their levels.',
+    },
+    {
+        key: 'importPending',
+        label: 'Import unverified runs',
+        hint: 'Runs still pending verification on speedrun.com (imported as pending).',
+    },
+    {
+        key: 'importGuests',
+        label: 'Import guest runs',
+        hint: 'Runs whose runner has no matched therun account (imported as guests).',
+    },
+    {
+        key: 'setMinTimeFloor',
+        label: 'Set a minimum-time floor',
+        hint: 'Flag impossibly-fast runs — below 90% of the fastest imported time.',
+    },
+];
+
+interface Props {
+    flags: ResolvedCommitFlags;
+    disabled: boolean;
+    onChange: (patch: SrcImportCommitFlags) => void;
+}
+
+export function ImportOptions({ flags, disabled, onChange }: Props) {
+    return (
+        <div className={styles.optionsPanel}>
+            <p className={styles.optionsTitle}>Import options</p>
+            <p className={styles.optionsHint}>
+                What this import writes. Every option defaults on (import
+                everything); set them before applying the configuration.
+            </p>
+            {TOGGLES.map((t) => (
+                <label key={t.key} className={styles.checkboxRow}>
+                    <input
+                        type="checkbox"
+                        checked={flags[t.key]}
+                        disabled={disabled}
+                        onChange={(e) =>
+                            onChange({ [t.key]: e.target.checked })
+                        }
+                    />
+                    <span>
+                        {t.label}
+                        <span className={styles.checkboxHint}>{t.hint}</span>
+                    </span>
+                </label>
+            ))}
+            {flags.importTheme && (
+                <div className={styles.themeModeRow}>
+                    <span>When a theme already exists:</span>
+                    <select
+                        className={styles.themeModeSelect}
+                        value={flags.themeMode}
+                        disabled={disabled}
+                        onChange={(e) =>
+                            onChange({
+                                themeMode: e.target.value as
+                                    | 'overwrite'
+                                    | 'if-unset',
+                            })
+                        }
+                    >
+                        <option value="overwrite">Overwrite it</option>
+                        <option value="if-unset">
+                            Keep it (only set if unset)
+                        </option>
+                    </select>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/app/(new-layout)/games-v2/[game]/manage/src-import/src-import-actions.ts
+++ b/app/(new-layout)/games-v2/[game]/manage/src-import/src-import-actions.ts
@@ -20,6 +20,7 @@ import {
     reconcileUndoSrcImport,
     type SrcImportPlayersQuery,
     type SrcImportRunsQuery,
+    setSrcImportFlags,
     setSrcImportOverrides,
     setSrcOnlyLeaderboard,
     startSrcImport,
@@ -32,6 +33,7 @@ import type {
     SrcCommitOverrides,
     SrcCommitPlan,
     SrcImportCategory,
+    SrcImportCommitFlags,
     SrcImportJob,
     SrcImportLevel,
     SrcImportPlayer,
@@ -278,6 +280,23 @@ export async function setSrcOnlyAction(input: {
             input.gameId,
             input.jobId,
             input.enabled,
+        );
+    });
+}
+
+export async function setFlagsAction(input: {
+    gameId: number;
+    gameSlug: string;
+    jobId: number;
+    flags: SrcImportCommitFlags;
+}): Promise<ActionResult<SrcImportCommitFlags>> {
+    return run(async () => {
+        const sessionId = await requireBoardMod(input.gameSlug);
+        return setSrcImportFlags(
+            sessionId,
+            input.gameId,
+            input.jobId,
+            input.flags,
         );
     });
 }

--- a/app/(new-layout)/games-v2/[game]/manage/src-import/src-import-pane.test.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/src-import/src-import-pane.test.tsx
@@ -93,6 +93,7 @@ const job = (over: Partial<SrcImportJob> = {}): SrcImportJob => ({
     srcOnlyLeaderboard: false,
     kind: 'manual',
     changeSummary: null,
+    commitFlags: null,
     ...over,
 });
 

--- a/app/(new-layout)/games-v2/[game]/manage/src-import/src-import.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/src-import/src-import.module.scss
@@ -430,6 +430,47 @@ $rail: 3px;
     font-size: dt.$font-size-xs;
 }
 
+// "Import options" — the moderator commit-flag toggles, shown while the plan
+// is being reviewed (before Apply config), the same lifecycle slot as the
+// SRC-only checkbox.
+.optionsPanel {
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.4);
+    border-radius: dt.$radius-md;
+    padding: dt.$spacing-md dt.$spacing-lg;
+    display: flex;
+    flex-direction: column;
+    gap: dt.$spacing-sm;
+}
+
+.optionsTitle {
+    font-size: dt.$font-size-sm;
+    font-weight: 600;
+    margin: 0;
+}
+
+.optionsHint {
+    color: var(--bs-secondary-color);
+    font-size: dt.$font-size-xs;
+    margin: 0;
+}
+
+.themeModeRow {
+    display: flex;
+    align-items: center;
+    gap: dt.$spacing-sm;
+    font-size: dt.$font-size-sm;
+    padding-left: dt.$spacing-lg;
+}
+
+.themeModeSelect {
+    background: var(--bs-body-bg);
+    color: var(--bs-body-color);
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.6);
+    border-radius: dt.$radius-md;
+    padding: 0.15rem 0.4rem;
+    font-size: dt.$font-size-xs;
+}
+
 .conflictList {
     margin: 0 0 dt.$spacing-sm;
     padding-left: dt.$spacing-lg;

--- a/src/lib/src-import.ts
+++ b/src/lib/src-import.ts
@@ -8,6 +8,7 @@ import type {
     SrcCommitOverrides,
     SrcCommitPlan,
     SrcImportCategory,
+    SrcImportCommitFlags,
     SrcImportJob,
     SrcImportLevel,
     SrcImportMatchKind,
@@ -240,6 +241,24 @@ export async function setSrcOnlyLeaderboard(
         `${base(gameId)}/${jobId}/src-only`,
         { method: 'POST', sessionId, body: { enabled } },
     );
+}
+
+/**
+ * Patch-merges the moderator commit flags onto the job (partial body — only the
+ * keys sent change; unrelated flags are kept). Returns the resolved flag set
+ * (defaults filled). The backend 409s once runs have started importing.
+ */
+export async function setSrcImportFlags(
+    sessionId: string,
+    gameId: number,
+    jobId: number,
+    flags: SrcImportCommitFlags,
+): Promise<SrcImportCommitFlags> {
+    return apiFetch<SrcImportCommitFlags>(`${base(gameId)}/${jobId}/flags`, {
+        method: 'POST',
+        sessionId,
+        body: flags,
+    });
 }
 
 function toQuery(q: object): string {

--- a/types/src-import.types.ts
+++ b/types/src-import.types.ts
@@ -54,9 +54,32 @@ export interface SrcImportJob {
     kind: SrcImportJobKind;
     /** What this commit changed — filled during the commit; null before it runs. */
     changeSummary: SrcCommitChangeSummary | null;
+    /**
+     * Per-job moderator commit toggles, set via POST .../flags before commit.
+     * Null (or a missing key) means the backend default — see resolveCommitFlags
+     * on the backend; every default preserves the prior import behavior.
+     */
+    commitFlags: SrcImportCommitFlags | null;
 }
 
 export type SrcImportJobKind = 'manual' | 'resync';
+
+/**
+ * Moderator toggles honored during the commit (mirror of the backend
+ * SrcImportCommitFlags). All keys optional; a missing key resolves to its
+ * behavior-preserving default (all booleans true, themeMode 'overwrite').
+ * Category/theme flags are consumed at apply-config, the run flags at
+ * import-runs; the backend freezes them once runs start importing.
+ */
+export interface SrcImportCommitFlags {
+    importTheme?: boolean;
+    themeMode?: 'overwrite' | 'if-unset';
+    importMiscCategories?: boolean;
+    importLevelCategories?: boolean;
+    importPending?: boolean;
+    importGuests?: boolean;
+    setMinTimeFloor?: boolean;
+}
 
 export interface SrcCommitChangeSummary {
     added: number;


### PR DESCRIPTION
## What

Adds an **"Import options"** panel to the SRC (speedrun.com) import commit console, letting a board moderator control what an import writes — matching the six backend `commitFlags` shipped in therun-backend.

Toggles (all default **on** = import everything; theme adds an overwrite / only-if-unset mode):
- Import board theme (+ theme mode)
- Import miscellaneous categories
- Import individual-level (IL) categories
- Import unverified runs
- Import guest runs
- Set a minimum-time floor

## How

- **Type** `SrcImportCommitFlags` mirrored into `types/src-import.types.ts` (+ `commitFlags` on `SrcImportJob`), from the backend contract (`therun/docs/frontend-guide-src-import-flags.md`).
- **Fetcher** `setSrcImportFlags` → `POST .../{jobId}/flags` (patch-merge; returns resolved flags).
- **Action** `setFlagsAction` (board-mod gated), mirroring `setSrcOnlyAction`.
- **UI** `ImportOptions` panel in `commit-panel.tsx` — optimistic local state, on-change persists only the changed key. Shown **only in the plan stage** (flags are consumed at apply-config; the backend freezes them once importing).

## Backend

Depends on the `commitFlags` backend feature, already merged + deployed to prod. Defaults preserve prior behavior, so this is safe to ship independently — an unset panel imports exactly as before.

## Tests

`commit-panel` tests extended (panel renders + defaults on, a toggle persists via `setFlagsAction` with only the changed key, panel hidden once applied). Full src-import suite: 53 pass. Typecheck clean for the touched files; biome + scss clean.
