### PR TITLE
Redesign: games-v2 mod console — open cockpit chrome + all panes

### DIFF
--- a/.interface-design/system.md
+++ b/.interface-design/system.md
@@ -72,6 +72,27 @@ everywhere in games-v2:
 - **Name the domain thing.** "runs", "board", "category", "verification" —
   never "items", "content", "entries" where a real word exists.
 
+## Console cockpit (redesign, 2026-09-01)
+
+The manage console dropped its framed-box chrome for an **open cockpit** (user-directed: the old
+console "looked uninspired… no overview"). Rules for every console surface:
+
+- **Chrome:** no frame box, no header row. `ConsoleChrome cockpit` renders a sidebar **spine**
+  (game cover + name masthead → nav groups → exit doors under a hairline) beside content sitting
+  directly on the page canvas, one hairline between them. Mobile keeps the overlay drawer behind
+  a slim topbar. Settings keeps the old framed/plain variants.
+- **Pane anatomy, everywhere:** `paneEyebrow` (the sidebar group: Queue/Structure/Game) over a
+  headline-scale `paneTitle` (`$font-size-2xl`, −0.02em), actions on the baseline, `paneLede`
+  below. No hairline under pane headers — structure comes from type scale and space.
+- **Overview is a control room, not a tile grid:** status headline (calm "All clear" or a
+  severity-led count), mono KPI band, top needs-attention preview rows (severity spines), health
+  + setup rail, import & sync card, and one quiet "Also here" row of remaining doors.
+- **Boards pane renders the real public `LeaderboardTable`** with curation slots
+  (`onQuickModerate`, selection, `tbodyFooter` add-runner ghost row) instead of a parallel mod
+  table — the board a moderator curates is the board runners see.
+- Active bans, roster, moderators are board-tables/roster rows on the shared vocabulary; the
+  moderators pane's monogram avatar uses `board-avatar`.
+
 ## Components
 
 - `console.module.scss` — shared console styles: `.shell`, `.sidebar`, `.navGroup`, `.navItem`/`.active`, `.surface`, `.severitySpine`/`--high`/`--med`/`--low`, `.time` (mono tabular), `.metaRow`, `.actionRow`, `.empty`.

--- a/app/(new-layout)/games-v2/[game]/manage/boards/board-curation.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/boards/board-curation.module.scss
@@ -11,14 +11,30 @@
     gap: dt.$spacing-lg;
 }
 
+// Console-only pane intro — the shared paneHeader/paneEyebrow/paneTitle/
+// paneLede anatomy comes from console.module.scss; this wrapper only trims
+// the lede's trailing margin so the root's own flex gap sets the rhythm.
+.paneIntro {
+    > :last-child {
+        margin-bottom: 0;
+    }
+}
+
+// The door back to the exact public board being curated, in the pane
+// header's action slot.
+.boardLink {
+    @include board.control-pill;
+    font-size: dt.$font-size-xs;
+    text-decoration: none;
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
+}
+
 // ---- Board controls toolbar (Task 12: Minimum / Reorder / Set default /
-// Display) — right-aligned, quiet icon+label control-pills so it reads as
-// part of the leaderboard's own control language rather than an admin bar
-// bolted on top.
-// Console-only top row: "View public board" on the left, BoardControls'
-// right-aligned toolbar opposite (a bare span holds the left slot when the
-// viewer can't see one side, so space-between keeps both anchored).
-.paneTopRow {
+// Display) — one composed row directly above the table: the board's scan
+// line (run count, marked-pile chip) on the left, BoardControls' quiet
+// icon+label control-pills on the right, so it reads as part of the
+// leaderboard's own control language rather than an admin bar bolted on top.
+.toolbar {
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -26,10 +42,17 @@
     gap: dt.$spacing-xs;
 }
 
-.boardLink {
-    @include board.control-pill;
-    font-size: dt.$font-size-xs;
-    text-decoration: none;
+.toolbarFilters {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: dt.$spacing-sm;
+}
+
+.boardCount {
+    @include board.mono-time;
+    font-size: dt.$font-size-2xs;
+    color: var(--bs-tertiary-color);
 }
 
 .controlsBar {
@@ -267,19 +290,42 @@
     }
 }
 
-// ---- Marked-pile filter chip ----
-// Quiet, left-aligned (unlike .controlsBar's right-aligned Task 12 toolbar)
-// since it sits with the bands/switcher, not the config controls.
-.markedBar {
-    display: flex;
-}
-
+// ---- Batch-selection bar ----
+// The console's sticky glass bar (system.md: glass is reserved for sticky
+// bars floating above scrolled content) — it rides above the table while
+// the moderator scrolls a long board with rows selected.
 .selectionBar {
+    @include board.board-glass;
+    position: sticky;
+    top: dt.$spacing-sm;
+    z-index: dt.$z-sticky;
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: dt.$spacing-sm;
+    padding: dt.$spacing-sm dt.$spacing-lg;
+    border-radius: dt.$radius-lg;
+    box-shadow: dt.$shadow-sm;
     font-size: dt.$font-size-sm;
     color: var(--bs-secondary-color);
+}
+
+.selectionCount {
+    @include board.mono-time;
+    font-size: dt.$font-size-sm;
+    font-weight: 600;
+    margin-right: dt.$spacing-sm;
+}
+
+.selectionBtn {
+    @include board.control-pill;
+    font-size: dt.$font-size-xs;
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
+}
+
+.selectionClear {
+    @include board.board-quiet-link;
+    margin-left: auto;
 }
 
 // ---- Board pager ----
@@ -297,10 +343,6 @@
     font-size: dt.$font-size-xs;
     color: var(--bs-secondary-color);
     font-variant-numeric: tabular-nums;
-}
-
-.selectionAction {
-    @include board.board-quiet-link;
 }
 
 // A row pinned in place by a pending removal (see PendingRemoval in
@@ -525,6 +567,29 @@
     @include board.board-dialog-textarea;
 }
 
+// The Move dialog's category select — same recipe as .dialogInput (recessed
+// fill, token border/radius, primary focus ring) on a native <select>, in
+// place of raw Bootstrap's form-select.
+.dialogSelect {
+    @include board.board-input-rules;
+    display: block;
+    width: 100%;
+    font-size: dt.$font-size-sm;
+    padding: dt.$spacing-sm;
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.6);
+    background: color-mix(
+        in srgb,
+        var(--bs-body-bg) 90%,
+        var(--bs-secondary-bg) 10%
+    );
+    color: var(--bs-body-color);
+    margin-bottom: dt.$spacing-sm;
+
+    &:disabled {
+        opacity: 0.6;
+    }
+}
+
 // Single-line sibling of .dialogTextarea — same recipe (dt tokens for
 // font-size/padding/border/radius/width, same focus ring) minus `resize`,
 // which only makes sense on a multi-line control. Used by the Remove
@@ -696,6 +761,10 @@
     @include board.board-empty;
 }
 
+.emptyIcon {
+    @include board.board-empty-icon;
+}
+
 .emptyTitle {
     @include board.board-empty-title;
 }
@@ -706,11 +775,19 @@
     margin: 0;
 }
 
-.loadingNote {
+// First-load placeholder inside the table surface: a stack of shimmer rows
+// shaped like the board rows about to replace them.
+.loadingRows {
+    display: flex;
+    flex-direction: column;
+    gap: dt.$spacing-sm;
     padding: dt.$spacing-lg;
-    text-align: center;
-    color: var(--bs-secondary-color);
-    font-size: dt.$font-size-sm;
+}
+
+.loadingRow {
+    @include board.board-skeleton;
+    height: 2.25rem;
+    border-radius: dt.$radius-sm;
 }
 
 // In-table empty state (the ghost row always renders below it, so an empty

--- a/app/(new-layout)/games-v2/[game]/manage/boards/board-curation.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/boards/board-curation.tsx
@@ -5,10 +5,13 @@ import { useEffect, useMemo, useState, useTransition } from 'react';
 import {
     ArrowLeftShort,
     ArrowRightShort,
+    BoxArrowUpRight,
     PinAngleFill,
+    Trophy,
 } from 'react-bootstrap-icons';
 import { toast } from 'react-toastify';
 import { reorderGroupsAction } from '~src/actions/category-group/reorder-groups.action';
+import consoleStyles from '~src/components/console-chrome/console.module.scss';
 import Link from '~src/components/link';
 import { UserLink } from '~src/components/links/links';
 import { buildBoardHref, buildBoardQuery } from '~src/lib/board-url';
@@ -48,6 +51,7 @@ import {
 import { BoardDialog } from '../../shared/board-dialog';
 import { reorderCategoriesAction } from '../game-tab/actions/reorder-categories.action';
 import { computeReorderChanges } from '../game-tab/reorder-changes';
+import type { ModVerb } from '../moderation/shared/action-model';
 import { moveRunAction } from '../moderation/shared/actions/board-override.action';
 import { loadUserEligibleRunsAction } from '../moderation/shared/actions/eligible-runs.action';
 import {
@@ -357,7 +361,7 @@ export function BoardCuration({
     // stale under the drawer.
     const [inspectRunId, setInspectRunId] = useState<number | null>(null);
     // Verb the drawer opens onto (a row's Remove/`x`); cleared on close/step.
-    const [inspectVerb, setInspectVerb] = useState<'remove' | null>(null);
+    const [inspectVerb, setInspectVerb] = useState<ModVerb | null>(null);
     const [boardPageIndex, setBoardPageIndex] = useState(0);
 
     const { rows, total, markedTotal, loading, error, reload } = useBoardData(
@@ -764,18 +768,63 @@ export function BoardCuration({
           )
         : 0;
 
+    // Console mounts wear the console's pane anatomy; the wizard embeds the
+    // same board without it. The door back to the exact public board being
+    // curated sits in the header's action slot — every moderator gets it,
+    // not just configurers. The wizard context has no public board yet.
+    const paneIntro = context === 'console' && (
+        <div className={styles.paneIntro}>
+            <header className={consoleStyles.paneHeader}>
+                <div>
+                    <div className={consoleStyles.paneEyebrow}>Structure</div>
+                    <h2 className={consoleStyles.paneTitle}>Boards</h2>
+                </div>
+                {category && (
+                    <div className={consoleStyles.paneActions}>
+                        <Link
+                            className={styles.boardLink}
+                            href={buildBoardHref(game.name, {
+                                categorySlug: category.name,
+                                subcategoryKey,
+                            })}
+                        >
+                            View public board
+                            <BoxArrowUpRight size={12} aria-hidden />
+                        </Link>
+                    </div>
+                )}
+            </header>
+            <p className={consoleStyles.paneLede}>
+                The public leaderboard with moderator actions on every run.
+            </p>
+        </div>
+    );
+
     if (featured.length === 0) {
         return (
-            <div className={styles.empty}>
-                <p className={styles.emptyTitle}>
-                    No categories are featured yet.
-                </p>
-                {canConfigure && (
-                    <p className={styles.emptyHint}>
-                        Feature at least one category to see its board here.
+            <section
+                className={styles.root}
+                aria-label={
+                    context === 'wizard' ? 'Board preview' : 'Board curation'
+                }
+            >
+                {paneIntro}
+                <div className={styles.empty}>
+                    <Trophy
+                        size={28}
+                        className={styles.emptyIcon}
+                        aria-hidden
+                    />
+                    <p className={styles.emptyTitle}>
+                        No categories are featured yet.
                     </p>
-                )}
-            </div>
+                    {canConfigure && (
+                        <p className={styles.emptyHint}>
+                            Feature at least one category to see its board here.
+                        </p>
+                    )}
+                </div>
+            </section>
         );
     }
 
@@ -786,42 +835,7 @@ export function BoardCuration({
                 context === 'wizard' ? 'Board preview' : 'Board curation'
             }
         >
-            {(canConfigure || context === 'console') && category && (
-                <div className={styles.paneTopRow}>
-                    {/* The door back to the exact public board being curated —
-                        every moderator gets it, not just configurers. The
-                        wizard context has no public board to point at yet. */}
-                    {context === 'console' ? (
-                        <Link
-                            className={styles.boardLink}
-                            href={buildBoardHref(game.name, {
-                                categorySlug: category.name,
-                                subcategoryKey,
-                            })}
-                        >
-                            View public board ↗
-                        </Link>
-                    ) : (
-                        <span />
-                    )}
-                    {canConfigure && (
-                        <BoardControls
-                            gameSlug={game.name}
-                            gameId={game.id}
-                            category={category}
-                            timing={timing}
-                            policies={policies}
-                            subcatVars={subcatVars}
-                            selectedValues={selectedValues}
-                            reorderMode={reorderMode}
-                            onToggleReorderMode={() =>
-                                setReorderMode((v) => !v)
-                            }
-                            reload={reload}
-                        />
-                    )}
-                </div>
-            )}
+            {paneIntro}
 
             <div className={styles.categorySwitch}>
                 {sections.map((section, idx) => {
@@ -990,47 +1004,77 @@ export function BoardCuration({
                 reorderBusy={isReordering}
             />
 
-            {(markedTotal > 0 || showMarkedOnly) && (
-                <div className={styles.markedBar}>
-                    <button
-                        type="button"
-                        aria-pressed={showMarkedOnly}
-                        className={`${styles.toolbarBtn} ${showMarkedOnly ? styles.toolbarBtnActive : ''}`}
-                        onClick={() => {
-                            setShowMarkedOnly((v) => !v);
-                            setBoardPageIndex(0);
-                        }}
-                    >
-                        <PinAngleFill size={11} aria-hidden />
-                        {markedTotal} marked
-                    </button>
+            {/* One composed toolbar directly above the table: the board's
+                scan line (run count, marked-pile filter) on the left, the
+                configure controls on the right. */}
+            {(markedTotal > 0 ||
+                showMarkedOnly ||
+                (canConfigure && category)) && (
+                <div className={styles.toolbar}>
+                    <div className={styles.toolbarFilters}>
+                        {!loading && !error && (
+                            <span className={styles.boardCount}>
+                                {pagerTotal}{' '}
+                                {showMarkedOnly ? 'marked runs' : 'runs'}
+                            </span>
+                        )}
+                        {(markedTotal > 0 || showMarkedOnly) && (
+                            <button
+                                type="button"
+                                aria-pressed={showMarkedOnly}
+                                className={`${styles.toolbarBtn} ${showMarkedOnly ? styles.toolbarBtnActive : ''}`}
+                                onClick={() => {
+                                    setShowMarkedOnly((v) => !v);
+                                    setBoardPageIndex(0);
+                                }}
+                            >
+                                <PinAngleFill size={11} aria-hidden />
+                                {markedTotal} marked
+                            </button>
+                        )}
+                    </div>
+                    {canConfigure && category && (
+                        <BoardControls
+                            gameSlug={game.name}
+                            gameId={game.id}
+                            category={category}
+                            timing={timing}
+                            policies={policies}
+                            subcatVars={subcatVars}
+                            selectedValues={selectedValues}
+                            reorderMode={reorderMode}
+                            onToggleReorderMode={() =>
+                                setReorderMode((v) => !v)
+                            }
+                            reload={reload}
+                        />
+                    )}
                 </div>
             )}
 
             {selectedRunIds.size > 0 && (
                 <div className={styles.selectionBar}>
-                    <span>{selectedRunIds.size} selected</span>
-                    <span aria-hidden="true">&middot;</span>
+                    <span className={styles.selectionCount}>
+                        {selectedRunIds.size} selected
+                    </span>
                     <button
                         type="button"
-                        className={styles.selectionAction}
+                        className={styles.selectionBtn}
                         onClick={handleBulkAccept}
                         disabled={isBulkAccepting}
                     >
                         Accept
                     </button>
-                    <span aria-hidden="true">&middot;</span>
                     <button
                         type="button"
-                        className={styles.selectionAction}
+                        className={styles.selectionBtn}
                         onClick={openBulkBan}
                     >
                         Ban…
                     </button>
-                    <span aria-hidden="true">&middot;</span>
                     <button
                         type="button"
-                        className={styles.selectionAction}
+                        className={styles.selectionClear}
                         onClick={clearSelection}
                     >
                         Clear
@@ -1042,7 +1086,17 @@ export function BoardCuration({
                 <div className={styles.wrapper}>
                     {error && <div className={styles.errorNote}>{error}</div>}
                     {!error && loading && rows.length === 0 && (
-                        <p className={styles.loadingNote}>Loading board…</p>
+                        <div
+                            className={styles.loadingRows}
+                            role="status"
+                            aria-label="Loading board"
+                        >
+                            <div className={styles.loadingRow} />
+                            <div className={styles.loadingRow} />
+                            <div className={styles.loadingRow} />
+                            <div className={styles.loadingRow} />
+                            <div className={styles.loadingRow} />
+                        </div>
                     )}
                     {!error && (!loading || rows.length > 0) && (
                         <LeaderboardTable
@@ -1063,7 +1117,7 @@ export function BoardCuration({
                             selectedKeys={selectedKeys}
                             onToggleSelect={handleToggleSelect}
                             onToggleAllVisible={handleToggleAllVisible}
-                            onModerate={(entry, verb) => {
+                            onQuickModerate={(entry, verb) => {
                                 setInspectVerb(verb ?? null);
                                 setInspectRunId(entry.runId ?? null);
                             }}

--- a/app/(new-layout)/games-v2/[game]/manage/boards/move-dialog.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/boards/move-dialog.tsx
@@ -234,7 +234,7 @@ export function MoveDialog({
                 </label>
                 <select
                     id="move-category"
-                    className="form-select form-select-sm mb-2"
+                    className={styles.dialogSelect}
                     value={targetCategoryId}
                     onChange={(e) => {
                         setTargetCategoryId(Number(e.target.value));

--- a/app/(new-layout)/games-v2/[game]/manage/boards/runner-dialog.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/boards/runner-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useId, useMemo, useState, useTransition } from 'react';
+import { BoxArrowUpRight } from 'react-bootstrap-icons';
 import { toast } from 'react-toastify';
 import Link from '~src/components/link';
 import type { RunTreatment } from '../../../../../../types/bans.types';
@@ -270,7 +271,8 @@ export function RunnerDialog({
                         <Link
                             href={`/games-v2/${encodeURIComponent(gameSlug)}/manage/moderation/runner/${row.userId}?from=${dossierFrom}`}
                         >
-                            View full runner page ↗
+                            View full runner page{' '}
+                            <BoxArrowUpRight size={12} aria-hidden />
                         </Link>
                     </p>
                 )}

--- a/app/(new-layout)/games-v2/[game]/manage/console/add-category-dialog.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/console/add-category-dialog.tsx
@@ -277,10 +277,7 @@ export function AddCategoryDialog({
                 {error && <p className={styles.pickerError}>{error}</p>}
             </div>
             <div className={styles.dialogFooter}>
-                <span
-                    className={styles.pickerMeta}
-                    style={{ marginRight: 'auto' }}
-                >
+                <span className={`${styles.pickerMeta} ${styles.footMeta}`}>
                     {progress ?? `${selected.size} selected`}
                 </span>
                 <button

--- a/app/(new-layout)/games-v2/[game]/manage/console/board-categories-table.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/console/board-categories-table.tsx
@@ -597,7 +597,11 @@ export function BoardCategoriesTable({
                                                             >
                                                                 {i + 1}
                                                             </span>
-                                                            <span className="d-inline-flex flex-column">
+                                                            <span
+                                                                className={
+                                                                    styles.orderArrows
+                                                                }
+                                                            >
                                                                 <button
                                                                     type="button"
                                                                     className={
@@ -845,7 +849,7 @@ export function BoardCategoriesTable({
                                 style={{ width: `${share}%` }}
                             />
                         </div>
-                        <span className="text-muted small">
+                        <span className={styles.coverageNote}>
                             {boardRows.length} categor
                             {boardRows.length === 1 ? 'y carries' : 'ies carry'}{' '}
                             {share}% of this game's finished runs
@@ -900,8 +904,7 @@ export function BoardCategoriesTable({
                                         </span>
                                         <button
                                             type="button"
-                                            className={styles.quietAction}
-                                            style={{ opacity: 1 }}
+                                            className={`${styles.quietAction} ${styles.restoreAction}`}
                                             disabled={pendingIds.has(row.id)}
                                             onClick={() =>
                                                 setVisibility(

--- a/app/(new-layout)/games-v2/[game]/manage/console/board-categories.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/console/board-categories.module.scss
@@ -125,6 +125,11 @@
     }
 }
 
+.orderArrows {
+    display: inline-flex;
+    flex-direction: column;
+}
+
 tbody tr:hover .orderBtn,
 tbody tr:focus-within .orderBtn {
     opacity: 1;
@@ -301,6 +306,11 @@ tbody tr:focus-within .quietAction {
     transition: width dt.$transition-base;
 }
 
+.coverageNote {
+    font-size: dt.$font-size-xs;
+    color: var(--bs-secondary-color);
+}
+
 .footRow {
     display: flex;
     align-items: baseline;
@@ -348,6 +358,12 @@ tbody tr:focus-within .quietAction {
 
 .archivedName {
     margin-right: auto;
+}
+
+// A quiet action that is the point of its row (Restore in the archived and
+// level lists) stays legible instead of waiting for hover.
+.restoreAction {
+    opacity: 1;
 }
 
 // ---- Empty board ----------------------------------------------
@@ -428,6 +444,11 @@ tbody tr:focus-within .quietAction {
 
 .pickerError {
     @include board.board-dialog-field-error;
+}
+
+// The selection count holds the dialog footer's left edge.
+.footMeta {
+    margin-right: auto;
 }
 
 .pickerFoot {
@@ -553,12 +574,6 @@ tbody tr:focus-within .quietAction {
 .levelRowName {
     margin-right: auto;
     color: var(--bs-secondary-color);
-}
-
-.levelRestore {
-    // The quiet action only reveals itself on row hover in the table; in this
-    // list it is the point of the row, so it stays legible.
-    opacity: 1;
 }
 
 .levelFlag {

--- a/app/(new-layout)/games-v2/[game]/manage/console/board-health-card.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/console/board-health-card.module.scss
@@ -1,0 +1,90 @@
+@use '../../../../styles/design-tokens' as dt;
+@use '../../../../styles/board' as board;
+
+// ============================================================
+// Board health — one quiet card. Rendered above CONFIGURE panes
+// (console-shell) and inside the overview's rail; the rail passes
+// a className zeroing the bottom margin.
+// ============================================================
+
+.card {
+    @include board.board-surface(dt.$spacing-lg dt.$spacing-xl);
+    margin-bottom: dt.$spacing-lg;
+}
+
+.head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: dt.$spacing-md;
+    margin-bottom: dt.$spacing-sm;
+}
+
+.eyebrow {
+    @include board.board-eyebrow;
+}
+
+// Grade pill, on the console's severity map: at-risk→red,
+// needs-attention→amber, healthy→neutral.
+.grade {
+    @include board.board-pill;
+
+    &[data-grade='at-risk'] {
+        background: color-mix(in srgb, #{dt.$accent-red} 16%, transparent);
+        color: dt.$accent-red;
+        border-color: transparent;
+    }
+    &[data-grade='needs-attention'] {
+        background: color-mix(in srgb, #{dt.$accent-amber} 18%, transparent);
+        color: color-mix(in srgb, #{dt.$accent-amber} 80%, var(--bs-body-color));
+        border-color: transparent;
+    }
+}
+
+.list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.row {
+    display: flex;
+    align-items: baseline;
+    gap: dt.$spacing-sm;
+    font-size: dt.$font-size-sm;
+
+    a {
+        color: inherit;
+        text-decoration-color: rgba(var(--bs-border-color-rgb), 0.8);
+        transition: color dt.$transition-fast;
+
+        &:hover {
+            color: var(--bs-primary);
+        }
+        &:focus-visible {
+            outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
+            outline-offset: 1px;
+        }
+    }
+}
+
+.iconBlocker {
+    color: dt.$accent-red;
+    flex-shrink: 0;
+    position: relative;
+    top: 1px;
+}
+
+.iconWarning {
+    color: dt.$accent-amber;
+    flex-shrink: 0;
+    position: relative;
+    top: 1px;
+}
+
+.iconInfo {
+    color: var(--bs-tertiary-color);
+    flex-shrink: 0;
+    position: relative;
+    top: 1px;
+}

--- a/app/(new-layout)/games-v2/[game]/manage/console/board-health-card.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/console/board-health-card.tsx
@@ -3,9 +3,9 @@ import {
     ExclamationTriangleFill,
     XOctagonFill,
 } from 'react-bootstrap-icons';
-import styles from '~src/components/console-chrome/console.module.scss';
 import Link from '~src/components/link';
 import type { BoardHealth } from '~src/lib/setup/health';
+import styles from './board-health-card.module.scss';
 
 const GRADE_LABEL = {
     healthy: 'Healthy',
@@ -13,45 +13,44 @@ const GRADE_LABEL = {
     'at-risk': 'At risk',
 } as const;
 
-const GRADE_CLASS = {
-    healthy: styles.sevPillLow,
-    'needs-attention': styles.sevPillMedium,
-    'at-risk': styles.sevPillHigh,
-} as const;
-
 interface Props {
     gameSlug: string;
     health: BoardHealth;
+    /** Layout hook for the overview rail (zeroes the above-pane margin). */
+    className?: string;
 }
 
-export function BoardHealthCard({ gameSlug, health }: Props) {
+export function BoardHealthCard({ gameSlug, health, className }: Props) {
     return (
-        <div className={styles.inlineCard}>
-            <span className={`${styles.pill} ${GRADE_CLASS[health.grade]}`}>
-                Board health: {GRADE_LABEL[health.grade]}
-            </span>
-            <div>
+        <div className={`${styles.card} ${className ?? ''}`}>
+            <div className={styles.head}>
+                <h3 className={styles.eyebrow}>Board health</h3>
+                <span className={styles.grade} data-grade={health.grade}>
+                    {GRADE_LABEL[health.grade]}
+                </span>
+            </div>
+            <div className={styles.list}>
                 {health.items.map((item) => (
                     <div
                         key={`${item.pane ?? 'none'}-${item.label}`}
-                        className={styles.healthRow}
+                        className={styles.row}
                     >
                         {item.severity === 'blocker' ? (
                             <XOctagonFill
                                 size={12}
-                                className={styles.healthIconBlocker}
+                                className={styles.iconBlocker}
                                 aria-hidden
                             />
                         ) : item.severity === 'warning' ? (
                             <ExclamationTriangleFill
                                 size={12}
-                                className={styles.healthIconWarning}
+                                className={styles.iconWarning}
                                 aria-hidden
                             />
                         ) : (
                             <DashLg
                                 size={12}
-                                className={styles.healthIconInfo}
+                                className={styles.iconInfo}
                                 aria-hidden
                             />
                         )}

--- a/app/(new-layout)/games-v2/[game]/manage/console/categories-pane.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/console/categories-pane.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { Plus } from 'react-bootstrap-icons';
 import styles from '~src/components/console-chrome/console.module.scss';
 import type { ManageCategoryRow, ManageGroup } from '~src/lib/category-mgmt';
 import type { CategoryConfigRow } from '~src/lib/console/category-rows';
@@ -18,6 +19,7 @@ import { CategoryBandPreview } from '../../setup/steps/category-band-preview';
 import { buildCategorySeed } from '../../setup/steps/category-seed';
 import type { ReorderChange } from '../game-tab/reorder-changes';
 import { AddCategoryDialog } from './add-category-dialog';
+import boardStyles from './board-categories.module.scss';
 import { BoardCategoriesTable } from './board-categories-table';
 
 interface Props {
@@ -101,18 +103,24 @@ export function CategoriesPane({
 
     return (
         <section className={styles.surface}>
-            <div className={styles.paneHeader}>
-                <h2 className={styles.paneTitle}>{CONCEPT_LABEL.categories}</h2>
+            <header className={styles.paneHeader}>
+                <div>
+                    <div className={styles.paneEyebrow}>Structure</div>
+                    <h2 className={styles.paneTitle}>
+                        {CONCEPT_LABEL.categories}
+                    </h2>
+                </div>
                 <div className={styles.paneActions}>
                     <button
                         type="button"
-                        className="btn btn-sm btn-primary"
+                        className={boardStyles.primaryAction}
                         onClick={() => setAddOpen(true)}
                     >
-                        + Add category to board
+                        <Plus size={16} aria-hidden="true" />
+                        Add category to board
                     </button>
                 </div>
-            </div>
+            </header>
             <p className={styles.paneLede}>
                 The categories on your board right now, in the order the public
                 page shows them.

--- a/app/(new-layout)/games-v2/[game]/manage/console/console-shell.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/console/console-shell.tsx
@@ -382,6 +382,7 @@ export function ConsoleShell({
                 }}
                 icons={NAV_ICON}
                 navAriaLabel="Game admin console"
+                cockpit
                 groups={groups}
                 activeItem={activeSidebarItem}
                 onNavigate={(id) => handleNavigate(id as NavItemId)}

--- a/app/(new-layout)/games-v2/[game]/manage/console/content-router.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/console/content-router.tsx
@@ -213,9 +213,12 @@ export function ContentRouter(props: ContentRouterProps) {
             return (
                 <div className={styles.surface}>
                     <div className={styles.paneHeader}>
-                        <h2 className={styles.paneTitle}>
-                            Subcategories &amp; filters
-                        </h2>
+                        <div>
+                            <div className={styles.paneEyebrow}>Structure</div>
+                            <h2 className={styles.paneTitle}>
+                                Subcategories &amp; filters
+                            </h2>
+                        </div>
                     </div>
                     <VariablesGrid
                         game={game}

--- a/app/(new-layout)/games-v2/[game]/manage/console/game-details-pane.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/console/game-details-pane.tsx
@@ -26,8 +26,11 @@ export function GameDetailsPane({
 
     return (
         <div className={styles.surface}>
-            <div className={styles.paneHeader}>
-                <h2 className={styles.paneTitle}>Details &amp; metadata</h2>
+            <header className={styles.paneHeader}>
+                <div>
+                    <div className={styles.paneEyebrow}>Game</div>
+                    <h2 className={styles.paneTitle}>Details &amp; metadata</h2>
+                </div>
                 <div className={styles.paneActions}>
                     <button
                         type="submit"
@@ -38,9 +41,9 @@ export function GameDetailsPane({
                         {busy ? 'Saving…' : 'Save details'}
                     </button>
                 </div>
-            </div>
+            </header>
             <p className={styles.paneLede}>
-                Shown on the public game page and in the setup wizard.
+                Cover, facts, and links shown on the public game page.
             </p>
             <GameDetailsForm
                 identifiers={identifiers}

--- a/app/(new-layout)/games-v2/[game]/manage/console/level-boards-band.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/console/level-boards-band.tsx
@@ -174,7 +174,7 @@ export function LevelBoardsBand({
                                                 </span>
                                                 <button
                                                     type="button"
-                                                    className={`${styles.quietAction} ${styles.levelRestore}`}
+                                                    className={`${styles.quietAction} ${styles.restoreAction}`}
                                                     disabled={pendingIds.has(
                                                         row.id,
                                                     )}

--- a/app/(new-layout)/games-v2/[game]/manage/console/moderators-pane.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/console/moderators-pane.module.scss
@@ -1,0 +1,108 @@
+@use '../../../../styles/design-tokens' as dt;
+@use '../../../../styles/board' as board;
+
+// Roster rows: avatar/monogram, name, role pill, quiet remove. One person
+// per row, scannable top to bottom.
+.roster {
+    display: flex;
+    flex-direction: column;
+    gap: dt.$spacing-xs;
+    margin: 0 0 dt.$spacing-2xl;
+    padding: 0;
+    list-style: none;
+}
+
+.row {
+    @include board.board-surface(dt.$spacing-sm dt.$spacing-lg);
+    border-radius: dt.$radius-md;
+    display: flex;
+    align-items: center;
+    gap: dt.$spacing-md;
+    font-size: dt.$font-size-sm;
+}
+
+.name {
+    font-weight: 600;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.rolePill {
+    @include board.board-pill;
+    flex-shrink: 0;
+}
+
+// Board admin carries the one brand green; a plain moderator stays neutral.
+.rolePillAdmin {
+    @include board.board-pill;
+    flex-shrink: 0;
+    background: rgba(var(--bs-primary-rgb), 0.12);
+    color: var(--bs-primary);
+    border-color: rgba(var(--bs-primary-rgb), 0.3);
+}
+
+.since {
+    margin-left: auto;
+    font-size: dt.$font-size-2xs;
+    color: var(--bs-tertiary-color);
+    white-space: nowrap;
+}
+
+// Quiet destructive: neutral at rest, $accent-red on hover (one-red rule).
+.removeBtn {
+    @include board.board-quiet-link;
+    flex-shrink: 0;
+
+    &:hover {
+        color: dt.$accent-red;
+    }
+}
+
+// ---- Empty state --------------------------------------------
+.empty {
+    @include board.board-empty;
+    margin-bottom: dt.$spacing-2xl;
+}
+
+.emptyIcon {
+    @include board.board-empty-icon;
+}
+
+.emptyTitle {
+    @include board.board-empty-title;
+}
+
+// ---- Add row ------------------------------------------------
+.addLabel {
+    @include board.board-eyebrow;
+    margin-bottom: dt.$spacing-sm;
+}
+
+.addRow {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: dt.$spacing-sm;
+
+    input {
+        max-width: 16rem;
+    }
+
+    select {
+        width: auto;
+    }
+}
+
+.avatar {
+    @include board.board-avatar(dt.$avatar-sm);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: dt.$font-size-xs;
+    font-weight: 700;
+    color: var(--bs-secondary-color);
+    background: color-mix(in srgb, var(--bs-body-bg) 85%, var(--bs-secondary-bg));
+    flex-shrink: 0;
+}

--- a/app/(new-layout)/games-v2/[game]/manage/console/moderators-pane.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/console/moderators-pane.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useState, useTransition } from 'react';
+import { PeopleFill } from 'react-bootstrap-icons';
 import { toast } from 'react-toastify';
 import styles from '~src/components/console-chrome/console.module.scss';
 import Link from '~src/components/link';
@@ -15,6 +16,7 @@ import {
 } from '../../setup/actions/manage-moderators.action';
 import { ConfirmDialog } from '../../shared/confirm-dialog';
 import kit from '../shared/form-kit.module.scss';
+import pane from './moderators-pane.module.scss';
 
 interface Props {
     gameSlug: string;
@@ -104,10 +106,16 @@ export function ModeratorsPane({
 
     return (
         <section className={styles.surface}>
-            <div className={styles.paneHeader}>
-                <h2 className={styles.paneTitle}>Moderators</h2>
+            <header className={styles.paneHeader}>
+                <div>
+                    <div className={styles.paneEyebrow}>Game</div>
+                    <h2 className={styles.paneTitle}>Moderators</h2>
+                </div>
                 <span className={styles.paneCount}>{mods.length}</span>
-            </div>
+            </header>
+            <p className={styles.paneLede}>
+                The team that verifies runs and configures this board.
+            </p>
             {pendingApplications > 0 && (
                 <div className={styles.noteInfo}>
                     {pendingApplications} pending application
@@ -115,61 +123,91 @@ export function ModeratorsPane({
                     <Link
                         href={`/games-v2/${encodeURIComponent(gameSlug)}/manage?pane=attention`}
                     >
-                        review in Needs attention
+                        Review in Needs attention
                     </Link>
                 </div>
             )}
-            <div className="mb-3">
-                {mods.map((m) => (
-                    <div key={m.assignmentId} className={styles.modRow}>
-                        <strong>{m.username}</strong>
-                        <span className={styles.pill}>
-                            {m.role === 'game-admin'
-                                ? 'board admin'
-                                : 'moderator'}
-                        </span>
-                        <span className="text-muted small">
-                            since {new Date(m.createdAt).toLocaleDateString()}
-                        </span>
-                        <button
-                            type="button"
-                            className="btn btn-sm btn-outline-danger ms-auto"
-                            disabled={isPending}
-                            onClick={() => removeMod(m)}
-                        >
-                            Remove
-                        </button>
-                    </div>
-                ))}
-                {mods.length === 0 && (
-                    <div className={`${styles.modRow} text-muted`}>
-                        No moderators on record yet.
-                    </div>
-                )}
-            </div>
-            <div className={`d-flex gap-2 ${styles.inviteRow}`}>
-                <input
-                    className="form-control w-auto"
-                    value={username}
-                    onChange={(e) => setUsername(e.target.value)}
-                    placeholder="Twitch username"
-                />
-                <select
-                    className="form-select w-auto"
-                    value={role}
-                    onChange={(e) => setRole(e.target.value as BoardModRole)}
+            {mods.length > 0 ? (
+                <ul className={pane.roster}>
+                    {mods.map((m) => (
+                        <li key={m.assignmentId} className={pane.row}>
+                            <span className={pane.avatar} aria-hidden="true">
+                                {m.username.slice(0, 1).toUpperCase()}
+                            </span>
+                            <span className={pane.name}>{m.username}</span>
+                            <span
+                                className={
+                                    m.role === 'game-admin'
+                                        ? pane.rolePillAdmin
+                                        : pane.rolePill
+                                }
+                            >
+                                {m.role === 'game-admin'
+                                    ? 'Board admin'
+                                    : 'Moderator'}
+                            </span>
+                            <span className={pane.since}>
+                                since{' '}
+                                {new Date(m.createdAt).toLocaleDateString()}
+                            </span>
+                            <button
+                                type="button"
+                                className={pane.removeBtn}
+                                disabled={isPending}
+                                onClick={() => removeMod(m)}
+                            >
+                                Remove
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            ) : (
+                <div className={pane.empty}>
+                    <PeopleFill
+                        size={28}
+                        className={pane.emptyIcon}
+                        aria-hidden
+                    />
+                    <p className={pane.emptyTitle}>No moderators yet</p>
+                    <p>Add the first one by Twitch username below.</p>
+                </div>
+            )}
+            <div>
+                <div className={pane.addLabel} id="add-moderator-label">
+                    Add a moderator
+                </div>
+                <div
+                    className={pane.addRow}
+                    role="group"
+                    aria-labelledby="add-moderator-label"
                 >
-                    <option value="game-mod">Moderator</option>
-                    <option value="game-admin">Board admin</option>
-                </select>
-                <button
-                    type="button"
-                    className={kit.saveBtn}
-                    disabled={isPending || !username.trim()}
-                    onClick={addMod}
-                >
-                    Add
-                </button>
+                    <input
+                        className="form-control"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
+                        placeholder="Twitch username"
+                        aria-label="Twitch username"
+                    />
+                    <select
+                        className="form-select"
+                        value={role}
+                        onChange={(e) =>
+                            setRole(e.target.value as BoardModRole)
+                        }
+                        aria-label="Role"
+                    >
+                        <option value="game-mod">Moderator</option>
+                        <option value="game-admin">Board admin</option>
+                    </select>
+                    <button
+                        type="button"
+                        className={kit.saveBtn}
+                        disabled={isPending || !username.trim()}
+                        onClick={addMod}
+                    >
+                        Add
+                    </button>
+                </div>
             </div>
             <ConfirmDialog
                 open={confirmRemove != null}

--- a/app/(new-layout)/games-v2/[game]/manage/console/subroute-chrome.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/console/subroute-chrome.tsx
@@ -90,6 +90,7 @@ export function SubrouteChrome({
             }}
             icons={NAV_ICON}
             navAriaLabel="Game admin console"
+            cockpit
             groups={groups}
             activeItem={activeItem}
             onNavigate={(id) => navigate(id as NavItemId)}

--- a/app/(new-layout)/games-v2/[game]/manage/console/theme-pane.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/console/theme-pane.module.scss
@@ -1,79 +1,235 @@
-.controls {
-    display: grid;
-    gap: 1rem;
-    max-width: 28rem;
-    margin-block: 1.25rem;
-}
+@use '../../../../styles/design-tokens' as dt;
+@use '../../../../styles/board' as board;
 
-.field {
+// The theme pane is a precision instrument: the color controls sit in one
+// panel on the left, the live preview stands beside them on the right, and
+// the two never scroll apart.
+.layout {
     display: grid;
-    gap: 0.375rem;
+    grid-template-columns: minmax(0, 24rem) minmax(0, 30rem);
+    gap: dt.$spacing-2xl;
+    align-items: start;
 
-    > span {
-        font-size: 0.8125rem;
-        font-weight: 600;
+    @media (max-width: 900px) {
+        grid-template-columns: minmax(0, 1fr);
     }
 }
 
-.bgRow {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
+.controls {
+    @include board.board-surface(dt.$spacing-xl);
+    display: grid;
+    gap: dt.$spacing-xl;
 }
 
+.controlLabel {
+    @include board.board-eyebrow;
+}
+
+// ---- Color swatches ----------------------------------------
+// The three color pickers as one row of designed objects: a color well over
+// its name, the hex value in mono beside it — a palette, not three stacked
+// form controls.
+.swatchRow {
+    display: flex;
+    flex-wrap: wrap;
+    gap: dt.$spacing-lg;
+    margin-top: dt.$spacing-sm;
+}
+
+.swatch {
+    display: flex;
+    align-items: center;
+    gap: dt.$spacing-sm;
+    margin: 0;
+}
+
+.swatchInput {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.6);
+    border-radius: dt.$radius-md;
+    background: none;
+    cursor: pointer;
+    transition: border-color dt.$transition-fast,
+        box-shadow dt.$transition-fast;
+
+    &::-webkit-color-swatch-wrapper {
+        padding: 3px;
+    }
+
+    &::-webkit-color-swatch {
+        border: 0;
+        border-radius: calc(#{dt.$radius-md} - 3px);
+    }
+
+    &::-moz-color-swatch {
+        border: 0;
+        border-radius: calc(#{dt.$radius-md} - 3px);
+    }
+
+    &:hover {
+        border-color: rgba(var(--bs-primary-rgb), 0.5);
+    }
+
+    &:focus-visible {
+        outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
+        outline-offset: 1px;
+    }
+}
+
+.swatchText {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+
+.swatchName {
+    font-size: dt.$font-size-xs;
+    font-weight: 600;
+}
+
+.swatchHex {
+    @include board.mono-time;
+    font-size: dt.$font-size-2xs;
+    color: var(--bs-tertiary-color);
+    text-transform: uppercase;
+}
+
+// ---- Topbar segmented control ------------------------------
 .segmented {
-    display: inline-flex;
-    border: 1px solid var(--bs-border-color);
-    border-radius: 6px;
-    overflow: hidden;
+    @include board.board-segmented;
+    margin-top: dt.$spacing-sm;
+    margin-bottom: 0;
     width: fit-content;
 }
 
-.seg,
-.segActive {
-    appearance: none;
-    border: 0;
-    padding: 0.375rem 0.875rem;
-    font-size: 0.8125rem;
+.seg {
+    @include board.board-segment;
     font-weight: 600;
-    cursor: pointer;
-    background: transparent;
-    color: var(--bs-secondary-color);
-
-    & + & {
-        border-left: 1px solid var(--bs-border-color);
-    }
-
-    &:hover {
-        color: var(--bs-body-color);
-    }
 }
 
 .segActive {
-    background: var(--bs-primary);
-    color: #fff;
+    @include board.board-segment;
+    @include board.board-segment-active;
+    font-weight: 600;
+}
 
-    &:hover {
-        color: #fff;
-    }
+// ---- Background image ---------------------------------------
+.bgRow {
+    display: flex;
+    align-items: center;
+    gap: dt.$spacing-md;
+    margin-top: dt.$spacing-sm;
 }
 
 .bgThumb {
     width: 96px;
     height: 54px;
     object-fit: cover;
-    border-radius: 4px;
-    border: 1px solid var(--bs-border-color);
+    border-radius: dt.$radius-sm;
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.6);
+}
+
+// Dashed drop-zone-shaped trigger: an object waiting for an image, not
+// another gray button.
+.uploadTile {
+    display: inline-flex;
+    align-items: center;
+    gap: dt.$spacing-sm;
+    margin-top: dt.$spacing-sm;
+    padding: dt.$spacing-sm dt.$spacing-lg;
+    border: 1px dashed rgba(var(--bs-border-color-rgb), 0.7);
+    border-radius: dt.$radius-md;
+    background: none;
+    color: var(--bs-secondary-color);
+    font-size: dt.$font-size-sm;
+    font-weight: 500;
+    cursor: pointer;
+    transition: border-color dt.$transition-fast, color dt.$transition-fast;
+
+    &:hover {
+        border-color: rgba(var(--bs-primary-rgb), 0.6);
+        color: var(--bs-emphasis-color);
+    }
+
+    &:focus-visible {
+        outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
+        outline-offset: 1px;
+    }
+
+    &:disabled {
+        opacity: 0.6;
+        cursor: default;
+    }
+}
+
+.uploadHint {
+    font-size: dt.$font-size-2xs;
+    color: var(--bs-tertiary-color);
+    margin-top: dt.$spacing-xs;
+}
+
+.removeImage {
+    @include board.board-quiet-link;
+    font-size: dt.$font-size-sm;
+
+    &:hover {
+        color: dt.$accent-red;
+    }
+}
+
+// ---- Panel opacity ------------------------------------------
+.rangeRow {
+    display: flex;
+    align-items: center;
+    gap: dt.$spacing-md;
+    margin-top: dt.$spacing-sm;
+}
+
+.range {
+    flex: 1;
+    max-width: 14rem;
+    accent-color: var(--bs-primary);
+
+    &:focus-visible {
+        outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
+        outline-offset: 2px;
+    }
+}
+
+.rangeValue {
+    @include board.mono-time;
+    font-size: dt.$font-size-sm;
+    min-width: 3ch;
+    text-align: right;
+}
+
+// ---- Remove theme (pane action) -----------------------------
+.removeTheme {
+    @include board.board-quiet-link;
+    font-size: dt.$font-size-sm;
+
+    &:hover {
+        color: dt.$accent-red;
+    }
+}
+
+// ---- Preview ------------------------------------------------
+.previewCol {
+    position: sticky;
+    top: dt.$spacing-lg;
+
+    @media (max-width: 900px) {
+        position: static;
+    }
 }
 
 .previewLabel {
-    margin-top: 1.5rem;
-    margin-bottom: 0.5rem;
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: var(--bs-secondary-color);
+    @include board.board-eyebrow;
+    margin-bottom: dt.$spacing-sm;
 }
 
 // Miniature of the real board — topbar + canvas + a themed panel — rendered
@@ -82,13 +238,12 @@
 // the panel are built from `currentColor` so they track the readable panel
 // ink automatically; the same trick keeps the topbar dots legible.
 .preview {
-    max-width: 30rem;
-    border-radius: 10px;
+    border-radius: dt.$radius-lg;
     overflow: hidden;
-    border: 1px solid var(--bs-border-color);
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.6);
     // A neutral frame around the mini-site so its own edges read as a window,
     // not part of the themed content.
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+    box-shadow: dt.$shadow-md;
 }
 
 // Site topbar strip. `default` falls back to the real dark-topbar surface;
@@ -96,9 +251,9 @@
 .previewTopbar {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: dt.$spacing-sm;
     height: 2rem;
-    padding-inline: 0.75rem;
+    padding-inline: dt.$spacing-md;
     background: var(--site-topbar-bg, rgba(18, 26, 17, 0.92));
     color: var(--site-topbar-color, rgba(232, 234, 237, 0.9));
     border-bottom: 1px solid rgba(0, 0, 0, 0.25);
@@ -114,7 +269,7 @@
 
 .previewNav {
     display: inline-flex;
-    gap: 0.5rem;
+    gap: dt.$spacing-sm;
     margin-left: auto;
 
     > i {
@@ -130,7 +285,7 @@
 // the optional background image layered on top.
 .previewCanvas {
     position: relative;
-    padding: 1.25rem 1.125rem 1.5rem;
+    padding: dt.$spacing-xl dt.$spacing-lg dt.$spacing-2xl;
     background: var(--site-canvas-bg);
 }
 
@@ -152,8 +307,8 @@
     position: relative;
     background: var(--board-surface-bg);
     border: 1px solid var(--board-surface-border);
-    border-radius: 8px;
-    padding: 0.875rem;
+    border-radius: dt.$radius-md;
+    padding: dt.$spacing-md;
     color: var(--board-ink);
 }
 
@@ -161,8 +316,8 @@
     display: flex;
     align-items: center;
     gap: 0.625rem;
-    padding-bottom: 0.75rem;
-    margin-bottom: 0.75rem;
+    padding-bottom: dt.$spacing-md;
+    margin-bottom: dt.$spacing-md;
     border-bottom: 1px solid var(--board-surface-border);
 }
 
@@ -180,7 +335,7 @@
     font-size: 0.625rem;
     font-weight: 700;
     line-height: 1;
-    padding: 0.25rem 0.5rem;
+    padding: dt.$spacing-xs dt.$spacing-sm;
     border-radius: 999px;
     background: var(--board-accent);
     color: var(--board-on-accent);
@@ -195,8 +350,8 @@
     display: flex;
     align-items: center;
     gap: 0.625rem;
-    padding: 0.375rem 0.5rem;
-    border-radius: 5px;
+    padding: 0.375rem dt.$spacing-sm;
+    border-radius: dt.$radius-sm;
 }
 
 // #1 row highlighted the way the real board flags the leader.

--- a/app/(new-layout)/games-v2/[game]/manage/console/theme-pane.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/console/theme-pane.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { type CSSProperties, useRef, useState } from 'react';
+import { Upload } from 'react-bootstrap-icons';
 import { toast } from 'react-toastify';
 import styles from '~src/components/console-chrome/console.module.scss';
 import type { GameIdentifiers, GameMetadata } from '~src/lib/game-mgmt';
@@ -106,13 +107,16 @@ export function ThemePane({ metadata, game }: Props) {
 
     return (
         <div className={styles.surface}>
-            <div className={styles.paneHeader}>
-                <h2 className={styles.paneTitle}>Theme</h2>
+            <header className={styles.paneHeader}>
+                <div>
+                    <div className={styles.paneEyebrow}>Game</div>
+                    <h2 className={styles.paneTitle}>Theme</h2>
+                </div>
                 <div className={styles.paneActions}>
                     {metadata.theme != null && (
                         <button
                             type="button"
-                            className="btn btn-sm btn-outline-danger"
+                            className={paneStyles.removeTheme}
                             disabled={busy}
                             onClick={() => {
                                 setDraft(null);
@@ -131,186 +135,274 @@ export function ThemePane({ metadata, game }: Props) {
                         {busy ? 'Saving…' : 'Save theme'}
                     </button>
                 </div>
-            </div>
+            </header>
 
             <p className={styles.paneLede}>
-                Give {game.name}&rsquo;s board its own look. Pick the panel,
-                accent, and page-background colors and optionally a background
-                image — text contrast is handled automatically.
+                Colors and an optional background image for the public board.
+                Text contrast adjusts automatically.
             </p>
 
-            <div className={paneStyles.controls}>
-                <label className={paneStyles.field}>
-                    <span>Panel color</span>
-                    <input
-                        type="color"
-                        value={t.panelColor}
-                        onChange={(e) =>
-                            setDraft({ ...t, panelColor: e.target.value })
-                        }
-                    />
-                </label>
-                <label className={paneStyles.field}>
-                    <span>Accent color</span>
-                    <input
-                        type="color"
-                        value={t.accentColor}
-                        onChange={(e) =>
-                            setDraft({ ...t, accentColor: e.target.value })
-                        }
-                    />
-                </label>
-                <label className={paneStyles.field}>
-                    <span>Page background</span>
-                    <input
-                        type="color"
-                        value={t.backgroundColor}
-                        onChange={(e) =>
-                            setDraft({ ...t, backgroundColor: e.target.value })
-                        }
-                    />
-                </label>
-                <div className={paneStyles.field}>
-                    <span>Topbar</span>
-                    <div
-                        className={paneStyles.segmented}
-                        role="group"
-                        aria-label="Topbar color"
-                    >
-                        {TOPBAR_STYLES.map((style) => (
-                            <button
-                                key={style}
-                                type="button"
-                                aria-pressed={t.topbar === style}
-                                className={
-                                    t.topbar === style
-                                        ? paneStyles.segActive
-                                        : paneStyles.seg
-                                }
-                                onClick={() =>
-                                    setDraft({ ...t, topbar: style })
-                                }
-                            >
-                                {TOPBAR_LABELS[style]}
-                            </button>
-                        ))}
-                    </div>
-                </div>
-                <div className={paneStyles.field}>
-                    <span>Background image</span>
-                    {t.backgroundUrl ? (
-                        <div className={paneStyles.bgRow}>
-                            {/* Backend media CDN; plain img is fine here. */}
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img
-                                src={t.backgroundUrl}
-                                alt=""
-                                className={paneStyles.bgThumb}
-                            />
-                            <button
-                                type="button"
-                                className="btn btn-sm btn-outline-secondary"
-                                disabled={busy}
-                                onClick={() =>
-                                    setDraft({ ...t, backgroundUrl: null })
-                                }
-                            >
-                                Remove image
-                            </button>
+            <div className={paneStyles.layout}>
+                <div className={paneStyles.controls}>
+                    <div>
+                        <div className={paneStyles.controlLabel}>Colors</div>
+                        <div className={paneStyles.swatchRow}>
+                            <label className={paneStyles.swatch}>
+                                <input
+                                    type="color"
+                                    className={paneStyles.swatchInput}
+                                    value={t.panelColor}
+                                    onChange={(e) =>
+                                        setDraft({
+                                            ...t,
+                                            panelColor: e.target.value,
+                                        })
+                                    }
+                                />
+                                <span className={paneStyles.swatchText}>
+                                    <span className={paneStyles.swatchName}>
+                                        Panel
+                                    </span>
+                                    <span className={paneStyles.swatchHex}>
+                                        {t.panelColor}
+                                    </span>
+                                </span>
+                            </label>
+                            <label className={paneStyles.swatch}>
+                                <input
+                                    type="color"
+                                    className={paneStyles.swatchInput}
+                                    value={t.accentColor}
+                                    onChange={(e) =>
+                                        setDraft({
+                                            ...t,
+                                            accentColor: e.target.value,
+                                        })
+                                    }
+                                />
+                                <span className={paneStyles.swatchText}>
+                                    <span className={paneStyles.swatchName}>
+                                        Accent
+                                    </span>
+                                    <span className={paneStyles.swatchHex}>
+                                        {t.accentColor}
+                                    </span>
+                                </span>
+                            </label>
+                            <label className={paneStyles.swatch}>
+                                <input
+                                    type="color"
+                                    className={paneStyles.swatchInput}
+                                    value={t.backgroundColor}
+                                    onChange={(e) =>
+                                        setDraft({
+                                            ...t,
+                                            backgroundColor: e.target.value,
+                                        })
+                                    }
+                                />
+                                <span className={paneStyles.swatchText}>
+                                    <span className={paneStyles.swatchName}>
+                                        Page background
+                                    </span>
+                                    <span className={paneStyles.swatchHex}>
+                                        {t.backgroundColor}
+                                    </span>
+                                </span>
+                            </label>
                         </div>
-                    ) : (
-                        <button
-                            type="button"
-                            className="btn btn-sm btn-outline-secondary"
-                            disabled={busy}
-                            onClick={() => fileInput.current?.click()}
-                        >
-                            Upload image (PNG/JPEG/WEBP, max 6 MB)
-                        </button>
-                    )}
-                    <input
-                        ref={fileInput}
-                        type="file"
-                        accept="image/png,image/jpeg,image/webp"
-                        hidden
-                        onChange={(e) => {
-                            const f = e.target.files?.[0];
-                            if (f) void uploadBackground(f);
-                            e.target.value = '';
-                        }}
-                    />
-                </div>
-                {t.backgroundUrl != null && (
-                    <label className={paneStyles.field}>
-                        <span>Panel opacity</span>
-                        <input
-                            type="range"
-                            min={85}
-                            max={100}
-                            value={Math.round(t.panelOpacity * 100)}
-                            onChange={(e) =>
-                                setDraft({
-                                    ...t,
-                                    panelOpacity: Number(e.target.value) / 100,
-                                })
-                            }
-                        />
-                    </label>
-                )}
-            </div>
-
-            <div className={paneStyles.previewLabel} aria-hidden>
-                Preview
-            </div>
-            <div className={paneStyles.preview} style={previewVars} aria-hidden>
-                <div
-                    className={paneStyles.previewTopbar}
-                    data-topbar={t.topbar}
-                >
-                    <span className={paneStyles.previewBrand} />
-                    <span className={paneStyles.previewNav}>
-                        <i />
-                        <i />
-                        <i />
-                    </span>
-                </div>
-                <div className={paneStyles.previewCanvas}>
-                    {previewTheme.backgroundUrl && (
+                    </div>
+                    <div>
+                        <div className={paneStyles.controlLabel}>Topbar</div>
                         <div
-                            className={paneStyles.previewBackdrop}
-                            style={{
-                                backgroundImage: `url(${previewTheme.backgroundUrl})`,
+                            className={paneStyles.segmented}
+                            role="group"
+                            aria-label="Topbar color"
+                        >
+                            {TOPBAR_STYLES.map((style) => (
+                                <button
+                                    key={style}
+                                    type="button"
+                                    aria-pressed={t.topbar === style}
+                                    className={
+                                        t.topbar === style
+                                            ? paneStyles.segActive
+                                            : paneStyles.seg
+                                    }
+                                    onClick={() =>
+                                        setDraft({ ...t, topbar: style })
+                                    }
+                                >
+                                    {TOPBAR_LABELS[style]}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+                    <div>
+                        <div className={paneStyles.controlLabel}>
+                            Background image
+                        </div>
+                        {t.backgroundUrl ? (
+                            <div className={paneStyles.bgRow}>
+                                {/* Backend media CDN; plain img is fine here. */}
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img
+                                    src={t.backgroundUrl}
+                                    alt=""
+                                    className={paneStyles.bgThumb}
+                                />
+                                <button
+                                    type="button"
+                                    className={paneStyles.removeImage}
+                                    disabled={busy}
+                                    onClick={() =>
+                                        setDraft({ ...t, backgroundUrl: null })
+                                    }
+                                >
+                                    Remove image
+                                </button>
+                            </div>
+                        ) : (
+                            <>
+                                <button
+                                    type="button"
+                                    className={paneStyles.uploadTile}
+                                    disabled={busy}
+                                    onClick={() => fileInput.current?.click()}
+                                >
+                                    <Upload size={16} aria-hidden />
+                                    Upload image
+                                </button>
+                                <div className={paneStyles.uploadHint}>
+                                    PNG, JPEG, or WEBP, up to 6 MB.
+                                </div>
+                            </>
+                        )}
+                        <input
+                            ref={fileInput}
+                            type="file"
+                            accept="image/png,image/jpeg,image/webp"
+                            hidden
+                            onChange={(e) => {
+                                const f = e.target.files?.[0];
+                                if (f) void uploadBackground(f);
+                                e.target.value = '';
                             }}
                         />
-                    )}
-                    <div className={paneStyles.previewPanel}>
-                        <div className={paneStyles.previewMast}>
-                            <span className={paneStyles.previewMastTitle} />
-                            <span className={paneStyles.previewPill}>PB</span>
-                        </div>
-                        <div className={paneStyles.previewBoard}>
-                            <div
-                                className={`${paneStyles.previewRow} ${paneStyles.previewRowLead}`}
+                    </div>
+                    {t.backgroundUrl != null && (
+                        <div>
+                            <label
+                                className={paneStyles.controlLabel}
+                                htmlFor="theme-panel-opacity"
                             >
-                                <span className={paneStyles.previewRank}>
-                                    1
+                                Panel opacity
+                            </label>
+                            <div className={paneStyles.rangeRow}>
+                                <input
+                                    id="theme-panel-opacity"
+                                    type="range"
+                                    className={paneStyles.range}
+                                    min={85}
+                                    max={100}
+                                    value={Math.round(t.panelOpacity * 100)}
+                                    onChange={(e) =>
+                                        setDraft({
+                                            ...t,
+                                            panelOpacity:
+                                                Number(e.target.value) / 100,
+                                        })
+                                    }
+                                />
+                                <span className={paneStyles.rangeValue}>
+                                    {Math.round(t.panelOpacity * 100)}%
                                 </span>
-                                <span className={paneStyles.previewName} />
-                                <span className={paneStyles.previewTime} />
                             </div>
-                            <div className={paneStyles.previewRow}>
-                                <span className={paneStyles.previewRank}>
-                                    2
-                                </span>
-                                <span className={paneStyles.previewName} />
-                                <span className={paneStyles.previewTime} />
-                            </div>
-                            <div className={paneStyles.previewRow}>
-                                <span className={paneStyles.previewRank}>
-                                    3
-                                </span>
-                                <span className={paneStyles.previewName} />
-                                <span className={paneStyles.previewTime} />
+                        </div>
+                    )}
+                </div>
+
+                <div className={paneStyles.previewCol}>
+                    <div className={paneStyles.previewLabel} aria-hidden>
+                        Preview
+                    </div>
+                    <div
+                        className={paneStyles.preview}
+                        style={previewVars}
+                        aria-hidden
+                    >
+                        <div
+                            className={paneStyles.previewTopbar}
+                            data-topbar={t.topbar}
+                        >
+                            <span className={paneStyles.previewBrand} />
+                            <span className={paneStyles.previewNav}>
+                                <i />
+                                <i />
+                                <i />
+                            </span>
+                        </div>
+                        <div className={paneStyles.previewCanvas}>
+                            {previewTheme.backgroundUrl && (
+                                <div
+                                    className={paneStyles.previewBackdrop}
+                                    style={{
+                                        backgroundImage: `url(${previewTheme.backgroundUrl})`,
+                                    }}
+                                />
+                            )}
+                            <div className={paneStyles.previewPanel}>
+                                <div className={paneStyles.previewMast}>
+                                    <span
+                                        className={paneStyles.previewMastTitle}
+                                    />
+                                    <span className={paneStyles.previewPill}>
+                                        PB
+                                    </span>
+                                </div>
+                                <div className={paneStyles.previewBoard}>
+                                    <div
+                                        className={`${paneStyles.previewRow} ${paneStyles.previewRowLead}`}
+                                    >
+                                        <span
+                                            className={paneStyles.previewRank}
+                                        >
+                                            1
+                                        </span>
+                                        <span
+                                            className={paneStyles.previewName}
+                                        />
+                                        <span
+                                            className={paneStyles.previewTime}
+                                        />
+                                    </div>
+                                    <div className={paneStyles.previewRow}>
+                                        <span
+                                            className={paneStyles.previewRank}
+                                        >
+                                            2
+                                        </span>
+                                        <span
+                                            className={paneStyles.previewName}
+                                        />
+                                        <span
+                                            className={paneStyles.previewTime}
+                                        />
+                                    </div>
+                                    <div className={paneStyles.previewRow}>
+                                        <span
+                                            className={paneStyles.previewRank}
+                                        >
+                                            3
+                                        </span>
+                                        <span
+                                            className={paneStyles.previewName}
+                                        />
+                                        <span
+                                            className={paneStyles.previewTime}
+                                        />
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/app/(new-layout)/games-v2/[game]/manage/game-tab/game-tab.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/game-tab/game-tab.tsx
@@ -44,9 +44,17 @@ export function GameTab({
 }: Props) {
     return (
         <section className={styles.surface}>
-            <div className={styles.paneHeader}>
-                <h2 className={styles.paneTitle}>{CONCEPT_LABEL.groups}</h2>
-            </div>
+            <header className={styles.paneHeader}>
+                <div>
+                    <div className={styles.paneEyebrow}>Structure</div>
+                    <h2 className={styles.paneTitle}>{CONCEPT_LABEL.groups}</h2>
+                </div>
+            </header>
+            <p className={styles.paneLede}>
+                Organize categories on the public game page. With more than one
+                group, the category rail splits into labeled sections in this
+                order.
+            </p>
             {/* Grouping is the one edit whose whole point is what the band
                 looks like afterwards — the wizard's step 3 shows it, so this
                 does too. */}

--- a/app/(new-layout)/games-v2/[game]/manage/game-tab/groups-section.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/game-tab/groups-section.module.scss
@@ -29,17 +29,27 @@
     @include board.board-btn-primary;
 }
 
+// The public board renders each group as a recessed well in the category
+// rail; this list is those wells being arranged, so it sits in the same
+// recess (the --board-recess-* custom properties the rail reads, with
+// canvas-tint fallbacks).
 .list {
     list-style: none;
     margin: 0;
-    padding: 0;
+    padding: dt.$spacing-xs;
+    border: 1px solid
+        var(--board-recess-border, rgba(var(--bs-border-color-rgb), 0.5));
+    border-radius: dt.$radius-lg;
+    background: var(--board-recess-bg, rgba(var(--bs-body-color-rgb), 0.04));
+    box-shadow: inset 0 2px 5px var(--board-recess-shadow, transparent);
 }
 
 .item {
     display: flex;
     align-items: center;
     gap: dt.$spacing-md;
-    padding: dt.$spacing-sm 0;
+    padding: dt.$spacing-sm dt.$spacing-md;
+    border-radius: dt.$radius-md;
     border-bottom: 1px solid rgba(var(--bs-border-color-rgb), 0.2);
     transition: background-color dt.$transition-fast;
 
@@ -47,8 +57,10 @@
         border-bottom: 0;
     }
 
+    // Rows lift out of the recess on hover, the way the rail's chips sit
+    // proud of their well.
     &:hover {
-        background: var(--bs-tertiary-bg);
+        background: var(--board-surface-bg, var(--bs-body-bg));
     }
 }
 
@@ -122,6 +134,11 @@
 
 .count {
     @include board.board-eyebrow;
+}
+
+.countNum {
+    @include board.mono-time;
+    font-size: dt.$font-size-2xs;
 }
 
 .nameInput {

--- a/app/(new-layout)/games-v2/[game]/manage/game-tab/groups-section.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/game-tab/groups-section.tsx
@@ -294,12 +294,6 @@ export function GroupsSection({
 
     return (
         <section>
-            <p className={styles.lede}>
-                Organize categories on the public game page. With more than one
-                group, the category rail splits into labeled sections in this
-                order.
-            </p>
-
             <div className={styles.panel}>
                 <div className={styles.createRow}>
                     <input
@@ -414,7 +408,13 @@ export function GroupsSection({
                                                     {g.name}
                                                 </span>
                                                 <span className={styles.count}>
-                                                    {count}{' '}
+                                                    <span
+                                                        className={
+                                                            styles.countNum
+                                                        }
+                                                    >
+                                                        {count}
+                                                    </span>{' '}
                                                     {count === 1
                                                         ? 'category'
                                                         : 'categories'}

--- a/app/(new-layout)/games-v2/[game]/manage/levels/level-categories-pane.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/levels/level-categories-pane.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { Check2, ChevronRight, Dash, Diagram3 } from 'react-bootstrap-icons';
 import { createLevelTemplateAction } from '~src/actions/levels/create-level-template.action';
 import { levelOpAction } from '~src/actions/levels/level-op.action';
 import consoleStyles from '~src/components/console-chrome/console.module.scss';
@@ -78,12 +79,19 @@ export function LevelCategoriesPane({ gameId, gameSlug }: Props) {
 
     return (
         <section className={consoleStyles.surface}>
-            <div className={consoleStyles.paneHeader}>
-                <h2 className={consoleStyles.paneTitle}>Level categories</h2>
-                <span className={consoleStyles.paneCount}>
-                    {templates.length}
-                </span>
-            </div>
+            <header className={consoleStyles.paneHeader}>
+                <div>
+                    <div className={consoleStyles.paneEyebrow}>Structure</div>
+                    <div className={styles.titleRow}>
+                        <h2 className={consoleStyles.paneTitle}>
+                            Level categories
+                        </h2>
+                        <span className={consoleStyles.paneCount}>
+                            {templates.length}
+                        </span>
+                    </div>
+                </div>
+            </header>
             <p className={consoleStyles.paneLede}>
                 The categories every level gets. Edit one here and the change
                 applies to each level&rsquo;s board.
@@ -91,80 +99,120 @@ export function LevelCategoriesPane({ gameId, gameSlug }: Props) {
 
             <InlineError>{error}</InlineError>
 
-            {loading && <p className="text-muted">Loading level categories…</p>}
+            {loading && (
+                <div
+                    className={styles.loading}
+                    role="status"
+                    aria-label="Loading level categories"
+                />
+            )}
 
             {!loading && !error && templates.length === 0 && (
                 <div className={styles.empty}>
-                    No level categories yet. Add one and every level gets a
-                    board for it.
+                    <Diagram3
+                        size={26}
+                        className={styles.emptyIcon}
+                        aria-hidden="true"
+                    />
+                    <p className={styles.emptyTitle}>No level categories yet</p>
+                    <p className={styles.emptyBlurb}>
+                        Add one and every level gets a board for it.
+                    </p>
                 </div>
             )}
 
             {templates.length > 0 && (
-                <table className={styles.table}>
-                    <thead>
-                        <tr>
-                            <th>Category</th>
-                            <th>Featured</th>
-                            <th>On levels</th>
-                            <th aria-label="Actions" />
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {templates.map((t) => (
-                            <tr key={t.id}>
-                                <td>{t.display}</td>
-                                <td>{t.isMain ? 'Featured' : '—'}</td>
-                                <td>
-                                    <span className={styles.count}>
-                                        {t.synced}/{t.total}
-                                    </span>
-                                    {t.excluded > 0 && (
-                                        <span
-                                            className={`${styles.pill} ${styles.pillExcluded} ms-2`}
-                                        >
-                                            {t.excluded} excluded
-                                        </span>
-                                    )}
-                                    {t.overridden > 0 && (
-                                        <span
-                                            className={`${styles.pill} ${styles.pillOverridden} ms-2`}
-                                        >
-                                            {t.overridden} edited on a level
-                                        </span>
-                                    )}
-                                </td>
-                                <td>
-                                    <div className="d-flex gap-2">
-                                        <Link
-                                            href={`/games-v2/${encodeURIComponent(gameSlug)}/manage/category/${t.id}`}
-                                        >
-                                            Edit
-                                        </Link>
-                                        <button
-                                            type="button"
-                                            className="btn btn-sm btn-outline-secondary"
-                                            aria-label={`Push ${t.display} now`}
-                                            disabled={isPending}
-                                            onClick={() => push(t.id)}
-                                        >
-                                            Push now
-                                        </button>
-                                        <button
-                                            type="button"
-                                            className="btn btn-sm btn-outline-danger"
-                                            aria-label={`Archive ${t.display}`}
-                                            disabled={isPending}
-                                            onClick={() => archive(t.id)}
-                                        >
-                                            Archive
-                                        </button>
-                                    </div>
-                                </td>
+                <div className={styles.panel}>
+                    <table className={styles.table}>
+                        <thead>
+                            <tr>
+                                <th>Category</th>
+                                <th className="text-center">Featured</th>
+                                <th>On levels</th>
+                                <th aria-label="Actions" />
                             </tr>
-                        ))}
-                    </tbody>
-                </table>
+                        </thead>
+                        <tbody>
+                            {templates.map((t) => (
+                                <tr key={t.id}>
+                                    <td className={styles.name}>{t.display}</td>
+                                    <td className="text-center">
+                                        {t.isMain ? (
+                                            <Check2
+                                                size={14}
+                                                className={styles.check}
+                                                aria-label="featured"
+                                            />
+                                        ) : (
+                                            <Dash
+                                                size={14}
+                                                className={styles.dash}
+                                                aria-label="not featured"
+                                            />
+                                        )}
+                                    </td>
+                                    <td>
+                                        <span
+                                            className={`${styles.count} ${
+                                                t.synced < t.total
+                                                    ? styles.countBehind
+                                                    : ''
+                                            }`}
+                                        >
+                                            {t.synced}/{t.total}
+                                        </span>
+                                        {t.excluded > 0 && (
+                                            <span
+                                                className={`${styles.pill} ${styles.pillExcluded} ms-2`}
+                                            >
+                                                {t.excluded} excluded
+                                            </span>
+                                        )}
+                                        {t.overridden > 0 && (
+                                            <span
+                                                className={`${styles.pill} ${styles.pillOverridden} ms-2`}
+                                            >
+                                                {t.overridden} edited on a level
+                                            </span>
+                                        )}
+                                    </td>
+                                    <td>
+                                        <div className={styles.rowActions}>
+                                            <button
+                                                type="button"
+                                                className={styles.quietAction}
+                                                aria-label={`Push ${t.display} now`}
+                                                disabled={isPending}
+                                                onClick={() => push(t.id)}
+                                            >
+                                                Push now
+                                            </button>
+                                            <button
+                                                type="button"
+                                                className={`${styles.quietAction} ${styles.archiveAction}`}
+                                                aria-label={`Archive ${t.display}`}
+                                                disabled={isPending}
+                                                onClick={() => archive(t.id)}
+                                            >
+                                                Archive
+                                            </button>
+                                            <Link
+                                                className={styles.pillAction}
+                                                href={`/games-v2/${encodeURIComponent(gameSlug)}/manage/category/${t.id}`}
+                                            >
+                                                Edit
+                                                <ChevronRight
+                                                    size={11}
+                                                    aria-hidden="true"
+                                                />
+                                            </Link>
+                                        </div>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
             )}
 
             <form
@@ -175,7 +223,7 @@ export function LevelCategoriesPane({ gameId, gameSlug }: Props) {
                 }}
             >
                 <input
-                    className="form-control form-control-sm w-auto"
+                    className={`form-control form-control-sm ${styles.createControl}`}
                     aria-label="New level category"
                     placeholder="Category name"
                     value={display}
@@ -183,7 +231,7 @@ export function LevelCategoriesPane({ gameId, gameSlug }: Props) {
                     onChange={(e) => setDisplay(e.target.value)}
                 />
                 <select
-                    className="form-select form-select-sm w-auto"
+                    className={`form-select form-select-sm ${styles.createControl}`}
                     aria-label="Primary timing"
                     value={timing}
                     disabled={isPending}

--- a/app/(new-layout)/games-v2/[game]/manage/levels/level-row.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/levels/level-row.tsx
@@ -137,7 +137,7 @@ export function LevelRow({
             {rulesOpen && (
                 <div className={styles.rulesBox}>
                     <textarea
-                        className="form-control form-control-sm"
+                        className={`form-control form-control-sm ${styles.rulesInput}`}
                         aria-label={`Rules for ${level.name}`}
                         rows={3}
                         value={rules}
@@ -192,7 +192,7 @@ export function LevelRow({
                             </span>
                             <button
                                 type="button"
-                                className="btn btn-sm btn-outline-secondary"
+                                className={styles.pillAction}
                                 aria-label={`Resync ${i.display} on ${level.name}`}
                                 disabled={isPending}
                                 onClick={() => resync(i.categoryId)}

--- a/app/(new-layout)/games-v2/[game]/manage/levels/levels-pane.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/levels/levels-pane.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { ListNested } from 'react-bootstrap-icons';
 import { createLevelAction } from '~src/actions/levels/create-level.action';
 import { levelOpAction } from '~src/actions/levels/level-op.action';
 import consoleStyles from '~src/components/console-chrome/console.module.scss';
@@ -66,44 +67,74 @@ export function LevelsPane({ gameId, gameSlug, templates }: Props) {
 
     return (
         <section className={consoleStyles.surface}>
-            <div className={consoleStyles.paneHeader}>
-                <h2 className={consoleStyles.paneTitle}>Levels</h2>
-                <span className={consoleStyles.paneCount}>{levels.length}</span>
+            <header className={consoleStyles.paneHeader}>
+                <div>
+                    <div className={consoleStyles.paneEyebrow}>Structure</div>
+                    <div className={styles.titleRow}>
+                        <h2 className={consoleStyles.paneTitle}>Levels</h2>
+                        <span className={consoleStyles.paneCount}>
+                            {levels.length}
+                        </span>
+                    </div>
+                </div>
                 {missingBoards && (
-                    <button
-                        type="button"
-                        className={kit.saveBtn}
-                        disabled={isPending}
-                        onClick={materialise}
-                    >
-                        Materialise missing boards
-                    </button>
+                    <div className={consoleStyles.paneActions}>
+                        <button
+                            type="button"
+                            className={styles.repairAction}
+                            disabled={isPending}
+                            onClick={materialise}
+                        >
+                            Materialise missing boards
+                        </button>
+                    </div>
                 )}
-            </div>
+            </header>
+            <p className={consoleStyles.paneLede}>
+                Name each level, set its rules, and choose which level
+                categories it carries.
+            </p>
 
             <InlineError>{error}</InlineError>
 
-            {loading && <p className="text-muted">Loading levels…</p>}
+            {loading && (
+                <div
+                    className={styles.loading}
+                    role="status"
+                    aria-label="Loading levels"
+                />
+            )}
 
             {!loading && !error && levels.length === 0 && (
                 <div className={styles.empty}>
-                    No levels yet.{' '}
-                    {templates.length === 0
-                        ? 'Add a level, then define the level categories every level gets.'
-                        : 'Add a level — every level category gets a board on it.'}
+                    <ListNested
+                        size={26}
+                        className={styles.emptyIcon}
+                        aria-hidden="true"
+                    />
+                    <p className={styles.emptyTitle}>No levels yet</p>
+                    <p className={styles.emptyBlurb}>
+                        {templates.length === 0
+                            ? 'Add a level, then define the level categories every level gets.'
+                            : 'Add a level: every level category gets a board on it.'}
+                    </p>
                 </div>
             )}
 
-            {levels.map((level) => (
-                <LevelRow
-                    key={level.id}
-                    gameId={gameId}
-                    gameSlug={gameSlug}
-                    level={level}
-                    templates={summaries}
-                    onChanged={reload}
-                />
-            ))}
+            {levels.length > 0 && (
+                <div className={styles.panel}>
+                    {levels.map((level) => (
+                        <LevelRow
+                            key={level.id}
+                            gameId={gameId}
+                            gameSlug={gameSlug}
+                            level={level}
+                            templates={summaries}
+                            onChanged={reload}
+                        />
+                    ))}
+                </div>
+            )}
 
             <form
                 className={styles.createRow}
@@ -113,7 +144,7 @@ export function LevelsPane({ gameId, gameSlug, templates }: Props) {
                 }}
             >
                 <input
-                    className="form-control form-control-sm w-auto"
+                    className={`form-control form-control-sm ${styles.createControl}`}
                     aria-label="New level name"
                     placeholder="Level name"
                     value={name}

--- a/app/(new-layout)/games-v2/[game]/manage/levels/levels.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/levels/levels.module.scss
@@ -58,8 +58,13 @@
 }
 
 .nameInput {
+    @include board.board-input-rules;
     font-weight: 600;
     max-width: 18rem;
+}
+
+.rulesInput {
+    @include board.board-input-rules;
 }
 
 .checklist {
@@ -113,6 +118,11 @@
     margin-top: dt.$spacing-lg;
 }
 
+.createControl {
+    @include board.board-input-rules;
+    width: auto;
+}
+
 .hint {
     font-size: dt.$font-size-sm;
     color: var(--bs-secondary-color);
@@ -125,4 +135,96 @@
 
 .empty {
     @include board.board-empty;
+}
+
+.emptyIcon {
+    @include board.board-empty-icon;
+}
+
+.emptyTitle {
+    @include board.board-empty-title;
+}
+
+.emptyBlurb {
+    margin: 0;
+}
+
+// ---- Pane header helpers ------------------------------------
+.titleRow {
+    display: flex;
+    align-items: baseline;
+    gap: dt.$spacing-sm;
+}
+
+// ---- Panel wrapper for the level rows -----------------------
+.panel {
+    display: flex;
+    flex-direction: column;
+    gap: dt.$spacing-sm;
+}
+
+// ---- Loading skeleton ---------------------------------------
+.loading {
+    @include board.board-skeleton;
+    min-height: 8rem;
+    border-radius: dt.$radius-md;
+}
+
+// ---- Actions ------------------------------------------------
+// Repair is the pane's one primary action when boards are missing.
+.repairAction {
+    @include board.board-btn-primary;
+}
+
+.rowActions {
+    display: inline-flex;
+    align-items: center;
+    gap: dt.$spacing-md;
+    white-space: nowrap;
+}
+
+.quietAction {
+    @include board.board-quiet-link;
+    border: 0;
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: default;
+    }
+}
+
+// Destructive tint on the quiet archive action (one-red rule).
+.archiveAction {
+    color: dt.$accent-red;
+
+    &:hover {
+        color: dt.$accent-red-light;
+    }
+}
+
+.pillAction {
+    @include board.control-pill;
+    display: inline-flex;
+    align-items: center;
+    gap: dt.$spacing-xs;
+    text-decoration: none;
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: default;
+    }
+}
+
+// ---- Sync state ---------------------------------------------
+// A board count that trails the level total needs a caution accent.
+.countBehind {
+    color: dt.$accent-amber;
+    font-weight: 600;
+}
+
+.dash {
+    color: var(--bs-tertiary-color);
 }

--- a/app/(new-layout)/games-v2/[game]/manage/moderation/attention/manual-time-verdict-row.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/moderation/attention/manual-time-verdict-row.module.scss
@@ -47,3 +47,10 @@
     display: flex;
     gap: dt.$spacing-sm;
 }
+
+// Quiet secondary tier for Cancel — the verdict button beside it keeps
+// the Bootstrap success/danger carve-out.
+.cancelBtn {
+    @include board.control-pill;
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
+}

--- a/app/(new-layout)/games-v2/[game]/manage/moderation/attention/manual-time-verdict-row.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/moderation/attention/manual-time-verdict-row.tsx
@@ -133,7 +133,7 @@ export function ManualTimeVerdictRow({
             <div className={styles.confirmRow}>
                 <button
                     type="button"
-                    className="btn btn-sm btn-outline-secondary"
+                    className={styles.cancelBtn}
                     onClick={() => {
                         setVerdict(null);
                         setReason('');

--- a/app/(new-layout)/games-v2/[game]/manage/moderation/attention/mod-applications-card.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/moderation/attention/mod-applications-card.module.scss
@@ -1,0 +1,121 @@
+@use '../../../../../styles/design-tokens' as dt;
+@use '../../../../../styles/board' as board;
+
+// ============================================================
+// Moderator applications — a contained callout above the queue.
+// One board surface; rows separated by hairlines, not boxes.
+// ============================================================
+
+.card {
+    @include board.board-surface(dt.$spacing-lg dt.$spacing-xl);
+    margin-bottom: dt.$spacing-2xl;
+}
+
+.head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: dt.$spacing-md;
+    padding-bottom: dt.$spacing-sm;
+    border-bottom: 1px solid rgba(var(--bs-border-color-rgb), 0.35);
+}
+
+.title {
+    font-size: dt.$font-size-md;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    margin: 0;
+}
+
+.headCount {
+    @include board.mono-time;
+    font-size: dt.$font-size-sm;
+    color: var(--bs-secondary-color);
+}
+
+.row {
+    padding: dt.$spacing-lg 0 dt.$spacing-md;
+
+    & + & {
+        border-top: 1px solid rgba(var(--bs-border-color-rgb), 0.35);
+    }
+}
+
+.rowTop {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: dt.$spacing-md;
+}
+
+.applicant {
+    font-weight: 600;
+}
+
+.signals {
+    font-size: dt.$font-size-xs;
+    color: var(--bs-secondary-color);
+}
+
+.motivation {
+    font-size: dt.$font-size-sm;
+    color: var(--bs-secondary-color);
+    white-space: pre-wrap;
+    margin: dt.$spacing-sm 0 dt.$spacing-md;
+    max-width: 70ch;
+}
+
+.rowActions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: dt.$spacing-sm;
+}
+
+.roleSelect {
+    font-size: dt.$font-size-sm;
+    padding: dt.$spacing-xs dt.$spacing-sm;
+    border-radius: dt.$radius-md;
+    background: color-mix(
+        in srgb,
+        var(--bs-body-bg) 90%,
+        var(--bs-secondary-bg) 10%
+    );
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.6);
+    color: var(--bs-body-color);
+    transition: border-color dt.$transition-fast;
+
+    &:hover {
+        border-color: rgba(var(--bs-primary-rgb), 0.5);
+    }
+    &:focus-visible {
+        outline: 0;
+        border-color: var(--bs-primary);
+        box-shadow: 0 0 0 3px rgba(var(--bs-primary-rgb), 0.15);
+    }
+    &:disabled {
+        opacity: 0.6;
+    }
+}
+
+.approveBtn {
+    @include board.board-btn-primary;
+    padding: dt.$spacing-xs dt.$spacing-lg;
+}
+
+// Quiet destructive tier — accent-red text per the one-red rule, no
+// filled chrome at rest (denying opens a confirm dialog anyway).
+.denyBtn {
+    @include board.control-pill;
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
+    color: dt.$accent-red;
+
+    &:hover {
+        background: color-mix(in srgb, #{dt.$accent-red} 8%, transparent);
+        color: dt.$accent-red;
+    }
+
+    &:focus-visible {
+        outline: 2px solid rgba(dt.$accent-red, 0.5);
+    }
+}

--- a/app/(new-layout)/games-v2/[game]/manage/moderation/attention/mod-applications-card.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/moderation/attention/mod-applications-card.tsx
@@ -3,7 +3,6 @@
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'react-toastify';
-import styles from '~src/components/console-chrome/console.module.scss';
 import type {
     BoardClaimRequest,
     BoardModRole,
@@ -13,6 +12,7 @@ import {
     approveApplicationAction,
     denyApplicationAction,
 } from './actions/decide-application.action';
+import styles from './mod-applications-card.module.scss';
 
 interface Props {
     gameSlug: string;
@@ -42,10 +42,10 @@ export function ModApplicationsCard({ gameSlug, applications }: Props) {
     };
 
     return (
-        <section className="mb-4">
-            <div className={styles.paneHeader}>
-                <h2 className={styles.paneTitle}>Moderator applications</h2>
-                <span className={styles.paneCount}>
+        <section className={styles.card}>
+            <div className={styles.head}>
+                <h2 className={styles.title}>Moderator applications</h2>
+                <span className={styles.headCount}>
                     {remaining.length} pending
                 </span>
             </div>
@@ -132,19 +132,17 @@ function ApplicationRow({
     };
 
     return (
-        <div className={`${styles.item} ${styles.sevLow} mb-2`}>
-            <div className={styles.itemTop}>
-                <strong>{request.username}</strong>
-                <span className="text-muted small">
+        <div className={styles.row}>
+            <div className={styles.rowTop}>
+                <span className={styles.applicant}>{request.username}</span>
+                <span className={styles.signals}>
                     {s.runsOnGame} runs on this game · {s.totalRuns} total
                 </span>
             </div>
-            <p className="mb-2 mt-1 small" style={{ whiteSpace: 'pre-wrap' }}>
-                {request.motivation}
-            </p>
-            <div className={styles.actionRow}>
+            <p className={styles.motivation}>{request.motivation}</p>
+            <div className={styles.rowActions}>
                 <select
-                    className="form-select form-select-sm w-auto"
+                    className={styles.roleSelect}
                     aria-label="Role to grant"
                     value={role}
                     onChange={(e) => setRole(e.target.value as BoardModRole)}
@@ -155,7 +153,7 @@ function ApplicationRow({
                 </select>
                 <button
                     type="button"
-                    className="btn btn-sm btn-primary"
+                    className={styles.approveBtn}
                     disabled={busy}
                     onClick={handleApprove}
                 >
@@ -163,7 +161,7 @@ function ApplicationRow({
                 </button>
                 <button
                     type="button"
-                    className="btn btn-sm btn-outline-danger"
+                    className={styles.denyBtn}
                     disabled={busy}
                     onClick={() => setDenyOpen(true)}
                 >

--- a/app/(new-layout)/games-v2/[game]/manage/moderation/attention/needs-attention.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/moderation/attention/needs-attention.module.scss
@@ -58,6 +58,73 @@ $rail: 3px;
     color: var(--bs-secondary-color);
 }
 
+// ---- Source filter chips (calm segmented row) ---------------
+.chipRow {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: dt.$spacing-xs;
+}
+
+.filterChip {
+    @include board.control-pill;
+}
+
+.filterChipActive {
+    @include board.control-pill-active;
+}
+
+// ---- Secondary (non-verdict) card action --------------------
+// The control-pill tier with a visible edge so it holds its own next
+// to the filled verdict buttons — same recipe as the console's
+// live-banner refresh pill.
+.quietBtn {
+    @include board.control-pill;
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
+    text-decoration: none;
+
+    &:hover {
+        text-decoration: none;
+    }
+}
+
+// ---- Severity tally (pane-header overview) ------------------
+.tally {
+    display: inline-flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: dt.$spacing-lg;
+}
+
+.tallyItem {
+    display: inline-flex;
+    align-items: baseline;
+    gap: dt.$spacing-xs;
+    font-size: dt.$font-size-xs;
+    color: var(--bs-secondary-color);
+}
+
+.tallyNum {
+    @include board.mono-time;
+    font-weight: 600;
+}
+
+.tallyDot {
+    align-self: center;
+    flex-shrink: 0;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--bs-secondary);
+
+    &[data-sev='high'] {
+        background: dt.$accent-red;
+    }
+    &[data-sev='medium'] {
+        background: dt.$accent-amber;
+    }
+}
+
 // ---- Dismissible URL-driven kind filter (e.g. arriving via "Reports") --
 .kindChip {
     display: inline-flex;
@@ -101,6 +168,22 @@ $rail: 3px;
     font-size: dt.$font-size-2xs;
     color: var(--bs-tertiary-color);
     margin-bottom: dt.$spacing-sm;
+
+    kbd {
+        font-family: dt.$font-mono;
+        font-size: dt.$font-size-2xs;
+        line-height: 1.4;
+        padding: 0 dt.$spacing-xs;
+        margin-right: 2px;
+        border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
+        border-radius: dt.$radius-sm;
+        background: color-mix(
+            in srgb,
+            var(--bs-body-bg) 94%,
+            var(--bs-secondary-bg) 6%
+        );
+        color: var(--bs-secondary-color);
+    }
 }
 
 .queuePosition {
@@ -119,11 +202,18 @@ $rail: 3px;
 // ---- A single run / claim card -----------------------------
 .card {
     position: relative;
-    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
+    border: 1px solid
+        var(--board-surface-border, rgba(var(--bs-border-color-rgb), 0.5));
     border-left-width: $rail;
     border-left-color: var(--bs-secondary);
     border-radius: dt.$radius-md;
-    background: var(--bs-body-bg);
+    // Lifted a clear step above the canvas (system.md signature 5), with
+    // the severity spine kept as the card's leading edge.
+    background: var(
+        --board-surface-bg,
+        color-mix(in srgb, var(--bs-body-bg) 92%, var(--bs-secondary-bg) 8%)
+    );
+    box-shadow: var(--board-surface-shadow, none);
     padding: dt.$spacing-lg dt.$spacing-xl;
     transition: box-shadow dt.$transition-base, border-color dt.$transition-fast;
 
@@ -301,8 +391,14 @@ $rail: 3px;
 
 // ---- Runner group (multiple items) -------------------------
 .group {
-    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
+    border: 1px solid
+        var(--board-surface-border, rgba(var(--bs-border-color-rgb), 0.5));
     border-radius: dt.$radius-md;
+    background: var(
+        --board-surface-bg,
+        color-mix(in srgb, var(--bs-body-bg) 92%, var(--bs-secondary-bg) 8%)
+    );
+    box-shadow: var(--board-surface-shadow, none);
     overflow: hidden;
 }
 
@@ -343,6 +439,16 @@ $rail: 3px;
     color: var(--bs-secondary-color);
 }
 
+.groupCountNum {
+    @include board.mono-time;
+    font-weight: 600;
+}
+
+// ---- Guest badge (no linked account) ------------------------
+.guestBadge {
+    @include board.board-pill;
+}
+
 .groupBody {
     display: flex;
     flex-direction: column;
@@ -351,9 +457,15 @@ $rail: 3px;
     border-top: 1px solid rgba(var(--bs-border-color-rgb), 0.4);
 }
 
-// nested cards inside a group sit flush (group provides the frame)
+// nested cards inside a group sit flush (group provides the frame and
+// the lift; a shadowed card inside a shadowed card would double-count)
 .groupBody .card {
-    background: color-mix(in srgb, var(--bs-body-bg) 96%, var(--bs-secondary-bg) 4%);
+    background: transparent;
+    box-shadow: none;
+
+    &:hover {
+        background: rgba(var(--bs-secondary-rgb), 0.06);
+    }
 }
 
 // ---- Empty state -------------------------------------------
@@ -370,6 +482,11 @@ $rail: 3px;
 
 .emptyTitle {
     @include board.board-empty-title;
+}
+
+.emptyText {
+    margin: 0;
+    color: var(--bs-secondary-color);
 }
 
 .emptyLinks {

--- a/app/(new-layout)/games-v2/[game]/manage/moderation/attention/needs-attention.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/moderation/attention/needs-attention.tsx
@@ -17,6 +17,7 @@ import {
     ShieldCheck,
     X,
 } from 'react-bootstrap-icons';
+import chrome from '~src/components/console-chrome/console.module.scss';
 import Link from '~src/components/link';
 import { UserLink } from '~src/components/links/links';
 import { DurationToFormatted } from '~src/components/util/datetime';
@@ -53,12 +54,22 @@ import {
 /** data-triage-card attribute name shared between the selector and the query. */
 const TRIAGE_CARD_ATTR = 'data-triage-card';
 
-// The triage-card action buttons repeat these three Bootstrap class strings
-// across ~13 sites (some inside clsx()). Named once so the whole card family
-// restyles from one place and the variants can't drift.
-const BTN_SECONDARY = 'btn btn-sm btn-outline-secondary';
+// The triage-card action buttons are named once so the whole card family
+// restyles from one place and the variants can't drift. Verdict actions
+// (approve/remove) keep the Bootstrap success/danger vocabulary per the
+// moderation verdict-action carve-out in system.md; secondary actions use
+// the board control-pill tier via this pane's own module.
+const BTN_SECONDARY = styles.quietBtn;
 const BTN_DANGER = 'btn btn-sm btn-outline-danger';
 const BTN_SUCCESS = 'btn btn-sm btn-success';
+
+const SOURCE_FILTERS: Array<{ value: SourceFilter; label: string }> = [
+    { value: 'all', label: 'All' },
+    { value: 'flag', label: 'Flags' },
+    { value: 'report', label: 'Reports' },
+    { value: 'appeal', label: 'Appeals' },
+    { value: 'self_claim', label: 'Self-claims' },
+];
 
 type SourceFilter = 'all' | AttentionSource;
 type CategoryFilter = 'any' | number;
@@ -216,6 +227,14 @@ export function NeedsAttention({
     }, [items, sourceFilter, kindFilter, categoryFilter]);
 
     const groups = useMemo(() => groupByRunner(filtered), [filtered]);
+
+    // Severity tally for the pane header — the scan-first overview of the
+    // whole queue (unfiltered, like the sidebar badge).
+    const sevTally = useMemo(() => {
+        const t: Record<FlagSeverity, number> = { high: 0, medium: 0, low: 0 };
+        for (const it of items) t[it.severity] += 1;
+        return t;
+    }, [items]);
 
     // The exact key order cards render in — respects collapsed runner
     // groups, shared by the roving j/k handler and the queue-position badge.
@@ -427,28 +446,67 @@ export function NeedsAttention({
 
     return (
         <div>
+            <header className={chrome.paneHeader}>
+                <div>
+                    <div className={chrome.paneEyebrow}>Queue</div>
+                    <h2 className={chrome.paneTitle}>Needs attention</h2>
+                </div>
+                <div className={chrome.paneActions}>
+                    {items.length > 0 && (
+                        <span className={styles.tally}>
+                            {(['high', 'medium', 'low'] as const).map(
+                                (sev) =>
+                                    sevTally[sev] > 0 && (
+                                        <span
+                                            key={sev}
+                                            className={styles.tallyItem}
+                                        >
+                                            <span
+                                                className={styles.tallyDot}
+                                                data-sev={sev}
+                                                aria-hidden="true"
+                                            />
+                                            <span className={styles.tallyNum}>
+                                                {sevTally[sev]}
+                                            </span>
+                                            {sev}
+                                        </span>
+                                    ),
+                            )}
+                        </span>
+                    )}
+                </div>
+            </header>
+            <p className={chrome.paneLede}>
+                Open flags, reports, appeals and self-claims on this game&apos;s
+                boards, highest severity first.
+            </p>
             <div className={styles.toolbar}>
                 <div className={styles.field}>
-                    <label
-                        htmlFor="attention-source"
-                        className={styles.fieldLabel}
-                    >
+                    <span className={styles.fieldLabel} id="attention-source">
                         Source
-                    </label>
-                    <select
-                        id="attention-source"
-                        className={styles.select}
-                        value={sourceFilter}
-                        onChange={(e) =>
-                            setSourceFilter(e.target.value as SourceFilter)
-                        }
+                    </span>
+                    <div
+                        className={styles.chipRow}
+                        role="group"
+                        aria-labelledby="attention-source"
                     >
-                        <option value="all">All sources</option>
-                        <option value="flag">Flags</option>
-                        <option value="report">Reports</option>
-                        <option value="appeal">Appeals</option>
-                        <option value="self_claim">Self-claims</option>
-                    </select>
+                        {SOURCE_FILTERS.map(({ value, label }) => (
+                            <button
+                                key={value}
+                                type="button"
+                                className={clsx(
+                                    styles.filterChip,
+                                    sourceFilter === value &&
+                                        styles.filterChipActive,
+                                )}
+                                aria-pressed={sourceFilter === value}
+                                onClick={() => setSourceFilter(value)}
+                            >
+                                {label}
+                            </button>
+                        ))}
+                    </div>
                 </div>
                 <div className={styles.field}>
                     <label
@@ -490,7 +548,9 @@ export function NeedsAttention({
                     </span>
                 )}
                 <div className={styles.count}>
-                    {filtered.length} item{filtered.length === 1 ? '' : 's'}
+                    {filtered.length === items.length
+                        ? `${filtered.length} item${filtered.length === 1 ? '' : 's'}`
+                        : `${filtered.length} of ${items.length}`}
                 </div>
             </div>
 
@@ -521,7 +581,7 @@ export function NeedsAttention({
                             aria-hidden="true"
                         />
                         <p className={styles.emptyTitle}>All clear</p>
-                        <p className="mb-0">
+                        <p className={styles.emptyText}>
                             Nothing needs attention right now.
                         </p>
                         <div className={styles.emptyLinks}>
@@ -571,10 +631,18 @@ export function NeedsAttention({
                         </div>
                     )}
                     <p className={styles.hint}>
-                        j/k navigate ·{' '}
-                        {isSelfClaimSelected
-                            ? 'v verify · r reject'
-                            : 'v approve · r remove · x select'}
+                        <kbd>j</kbd>
+                        <kbd>k</kbd> navigate ·{' '}
+                        {isSelfClaimSelected ? (
+                            <>
+                                <kbd>v</kbd> verify · <kbd>r</kbd> reject
+                            </>
+                        ) : (
+                            <>
+                                <kbd>v</kbd> approve · <kbd>r</kbd> remove ·{' '}
+                                <kbd>x</kbd> select
+                            </>
+                        )}
                         {queuePos && (
                             <span className={styles.queuePosition}>
                                 {queuePos.n} of {queuePos.m}
@@ -735,7 +803,7 @@ function ItemMeta({ item }: { item: AttentionItem }) {
                 {isGuest ? (
                     <>
                         {item.runnerName}{' '}
-                        <span className="badge text-bg-secondary">guest</span>
+                        <span className={styles.guestBadge}>guest</span>
                     </>
                 ) : (
                     <UserLink username={item.runnerName} />
@@ -1049,7 +1117,8 @@ function RunnerGroupCard({
                     )}
                 </button>
                 <span className={styles.groupCountText}>
-                    {items.length} items needing attention
+                    <span className={styles.groupCountNum}>{items.length}</span>{' '}
+                    open
                 </span>
                 <div className={clsx(styles.actions, styles.pushEnd)}>
                     {userId != null && (

--- a/app/(new-layout)/games-v2/[game]/manage/moderation/configure/active-bans.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/moderation/configure/active-bans.module.scss
@@ -2,118 +2,122 @@
 @use '../../../../../styles/board' as board;
 
 // ============================================================
-// Active Bans — standing exclusions list.
-// Token-based surfaces; severity spine pattern from the console.
+// Active bans — standing exclusions as a board table.
+// Red is the severity accent (one-red rule); everything else quiet.
 // ============================================================
 
-// ---- Section wrapper ----------------------------------------
 .section {
     margin-bottom: dt.$spacing-3xl;
 }
 
-.heading {
-    font-size: dt.$font-size-md;
-    font-weight: dt.$heading-font-weight;
-    margin-bottom: dt.$spacing-xs;
+// ---- Table ---------------------------------------------------
+.tableWrap {
+    overflow-x: auto;
 }
 
-.description {
-    font-size: dt.$font-size-sm;
-    color: var(--bs-secondary-color);
-    margin-bottom: dt.$spacing-lg;
+.table {
+    @include board.board-table;
+    width: 100%;
 }
 
-// ---- Stack of ban rows --------------------------------------
-.stack {
-    display: flex;
-    flex-direction: column;
-    gap: dt.$spacing-md;
-}
-
-// ---- A single ban card --------------------------------------
-$rail: 3px;
-
-.card {
-    position: relative;
-    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
-    border-left-width: $rail;
-    border-left-color: dt.$accent-red;
-    border-radius: dt.$radius-md;
-    background: var(--bs-body-bg);
-    padding: dt.$spacing-md dt.$spacing-xl;
-    transition: box-shadow dt.$transition-base;
-
-    &:hover {
-        box-shadow: dt.$shadow-md;
+.row {
+    td {
+        vertical-align: top;
     }
 }
 
-// ---- Card layout --------------------------------------------
-.cardRow {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: dt.$spacing-md;
-}
-
-.cardMeta {
-    display: flex;
-    flex-direction: column;
-    gap: dt.$spacing-xs;
-    font-size: dt.$font-size-sm;
+.runnerCell {
+    min-width: 14rem;
 }
 
 .runner {
     font-weight: 600;
 }
 
-.metaLine {
-    color: var(--bs-secondary-color);
-    font-size: dt.$font-size-sm;
-}
-
-.metaDate {
-    @include board.mono-time;
-    font-size: dt.$font-size-2xs;
-    color: var(--bs-tertiary-color);
-}
-
 .banReason {
+    display: block;
     font-size: dt.$font-size-sm;
     color: var(--bs-secondary-color);
     margin-top: dt.$spacing-xs;
     padding-left: dt.$spacing-md;
     border-left: 2px solid rgba(var(--bs-border-color-rgb), 0.5);
+    max-width: 48ch;
 }
 
-// ---- Lift inline form ---------------------------------------
+.scopePill {
+    @include board.board-pill;
+}
+
+.scopePillGame {
+    @include board.board-pill(dt.$accent-red);
+}
+
+.byCell {
+    color: var(--bs-secondary-color);
+    white-space: nowrap;
+}
+
+.dateCell {
+    @include board.mono-time;
+    font-size: dt.$font-size-xs;
+    color: var(--bs-tertiary-color);
+    white-space: nowrap;
+}
+
+.actionCell {
+    text-align: right;
+    white-space: nowrap;
+}
+
+// Quiet destructive text action — loud only on hover.
+.liftBtn {
+    border: 0;
+    background: transparent;
+    padding: 0;
+    font-size: dt.$font-size-sm;
+    font-weight: 600;
+    color: dt.$accent-red;
+    cursor: pointer;
+    border-radius: dt.$radius-sm;
+    transition: color dt.$transition-fast;
+
+    &:hover {
+        color: dt.$accent-red-light;
+        text-decoration: underline;
+    }
+
+    &:focus-visible {
+        outline: 2px solid color-mix(in srgb, #{dt.$accent-red} 50%, transparent);
+        outline-offset: 2px;
+    }
+}
+
+// ---- Inline lift form (expanded row) -------------------------
+.liftRow {
+    td {
+        background: color-mix(
+            in srgb,
+            var(--bs-body-bg) 94%,
+            #{dt.$accent-red} 6%
+        );
+        border-left: 3px solid dt.$accent-red;
+    }
+}
+
 .liftForm {
     display: flex;
     flex-direction: column;
     gap: dt.$spacing-sm;
-    min-width: 260px;
+    padding: dt.$spacing-sm 0;
+    max-width: 32rem;
+}
+
+.liftLabel {
+    @include board.board-eyebrow;
 }
 
 .liftTextarea {
-    font-size: dt.$font-size-sm;
-    border-radius: dt.$radius-sm;
-    border: 1px solid rgba(var(--bs-border-color-rgb), 0.6);
-    background: color-mix(in srgb, var(--bs-body-bg) 90%, var(--bs-secondary-bg) 10%);
-    color: var(--bs-body-color);
-    padding: dt.$spacing-xs dt.$spacing-sm;
-    resize: vertical;
-    transition: border-color dt.$transition-fast;
-
-    &:focus-visible {
-        outline: 0;
-        border-color: var(--bs-primary);
-        box-shadow: 0 0 0 3px rgba(var(--bs-primary-rgb), 0.15);
-    }
-
-    &:disabled {
-        opacity: 0.6;
-    }
+    @include board.board-dialog-textarea;
 }
 
 .liftActions {
@@ -122,14 +126,38 @@ $rail: 3px;
     justify-content: flex-end;
 }
 
+.cancelBtn {
+    @include board.control-pill;
+}
+
+.confirmBtn {
+    @include board.board-dialog-btn-danger;
+}
+
 // ---- Loading / empty / error states -------------------------
 .loading {
     display: flex;
-    align-items: center;
+    flex-direction: column;
     gap: dt.$spacing-sm;
-    font-size: dt.$font-size-sm;
-    color: var(--bs-secondary-color);
-    padding: dt.$spacing-lg 0;
+    padding: dt.$spacing-md 0;
+}
+
+.skeletonRow {
+    @include board.board-skeleton;
+    height: 2.25rem;
+    border-radius: dt.$radius-sm;
+}
+
+.srOnly {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 .empty {
@@ -142,6 +170,12 @@ $rail: 3px;
 
 .emptyTitle {
     @include board.board-empty-title;
+}
+
+.emptyText {
+    font-size: dt.$font-size-sm;
+    color: var(--bs-secondary-color);
+    margin: 0;
 }
 
 .errorAlert {

--- a/app/(new-layout)/games-v2/[game]/manage/moderation/configure/active-bans.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/moderation/configure/active-bans.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useEffect, useState, useTransition } from 'react';
-import { PersonSlash, ShieldCheck } from 'react-bootstrap-icons';
+import { ShieldCheck } from 'react-bootstrap-icons';
 import { toast } from 'react-toastify';
+import chrome from '~src/components/console-chrome/console.module.scss';
 import { UserLink } from '~src/components/links/links';
 import type { GameExclusionRuleRow } from '../../../../../../../types/moderation.types';
 import { deleteRuleAction } from '../rules/actions/delete-rule.action';
@@ -53,80 +54,94 @@ function BanRow({
     };
 
     return (
-        <div className={styles.card}>
-            <div className={styles.cardRow}>
-                <div className={styles.cardMeta}>
+        <>
+            <tr className={styles.row}>
+                <td className={styles.runnerCell}>
                     <span className={styles.runner}>
                         <UserLink username={rule.targetDisplayName} />
                     </span>
-                    <span className={styles.metaLine}>
-                        Banned from{' '}
-                        {rule.categoryName ?? <em>the whole game</em>} · by{' '}
-                        {rule.excludedByName}
-                    </span>
-                    <span className={styles.metaDate}>
-                        {new Date(rule.createdAt).toLocaleDateString()}
-                    </span>
                     {rule.reason && (
-                        <div className={styles.banReason}>{rule.reason}</div>
+                        <span className={styles.banReason}>{rule.reason}</span>
                     )}
-                </div>
-
-                {!expanded ? (
-                    <button
-                        type="button"
-                        className="btn btn-sm btn-outline-danger"
-                        onClick={() => {
-                            setExpanded(true);
-                            setError(null);
-                        }}
-                    >
-                        <PersonSlash
-                            size={13}
-                            aria-hidden="true"
-                            className="me-1"
-                        />
-                        Lift ban
-                    </button>
-                ) : (
-                    <div className={styles.liftForm}>
-                        <textarea
-                            className={styles.liftTextarea}
-                            rows={2}
-                            placeholder={`Reason (min ${MIN_REASON} chars)`}
-                            value={reason}
-                            onChange={(e) => setReason(e.target.value)}
-                            disabled={isPending}
-                        />
-                        {error && (
-                            <div className={styles.errorAlert}>{error}</div>
-                        )}
-                        <div className={styles.liftActions}>
-                            <button
-                                type="button"
-                                className="btn btn-sm btn-outline-secondary"
-                                onClick={() => {
-                                    setExpanded(false);
-                                    setReason('');
-                                    setError(null);
-                                }}
+                </td>
+                <td>
+                    {rule.categoryName ? (
+                        <span className={styles.scopePill}>
+                            {rule.categoryName}
+                        </span>
+                    ) : (
+                        <span className={styles.scopePillGame}>Whole game</span>
+                    )}
+                </td>
+                <td className={styles.byCell}>{rule.excludedByName}</td>
+                <td className={styles.dateCell}>
+                    {new Date(rule.createdAt).toLocaleDateString()}
+                </td>
+                <td className={styles.actionCell}>
+                    {!expanded && (
+                        <button
+                            type="button"
+                            className={styles.liftBtn}
+                            onClick={() => {
+                                setExpanded(true);
+                                setError(null);
+                            }}
+                        >
+                            Lift ban
+                        </button>
+                    )}
+                </td>
+            </tr>
+            {expanded && (
+                <tr className={styles.liftRow}>
+                    <td colSpan={5}>
+                        <div className={styles.liftForm}>
+                            <label
+                                htmlFor={`lift-reason-${rule.ruleId}`}
+                                className={styles.liftLabel}
+                            >
+                                Reason for lifting (min {MIN_REASON} characters)
+                            </label>
+                            <textarea
+                                id={`lift-reason-${rule.ruleId}`}
+                                className={styles.liftTextarea}
+                                rows={2}
+                                value={reason}
+                                onChange={(e) => setReason(e.target.value)}
                                 disabled={isPending}
-                            >
-                                Cancel
-                            </button>
-                            <button
-                                type="button"
-                                className="btn btn-sm btn-danger"
-                                onClick={handleLift}
-                                disabled={isPending || !reasonOk}
-                            >
-                                {isPending ? 'Lifting…' : 'Confirm lift'}
-                            </button>
+                            />
+                            {error && (
+                                <div className={styles.errorAlert} role="alert">
+                                    {error}
+                                </div>
+                            )}
+                            <div className={styles.liftActions}>
+                                <button
+                                    type="button"
+                                    className={styles.cancelBtn}
+                                    onClick={() => {
+                                        setExpanded(false);
+                                        setReason('');
+                                        setError(null);
+                                    }}
+                                    disabled={isPending}
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    type="button"
+                                    className={styles.confirmBtn}
+                                    onClick={handleLift}
+                                    disabled={isPending || !reasonOk}
+                                >
+                                    {isPending ? 'Lifting…' : 'Confirm lift'}
+                                </button>
+                            </div>
                         </div>
-                    </div>
-                )}
-            </div>
-        </div>
+                    </td>
+                </tr>
+            )}
+        </>
     );
 }
 
@@ -157,15 +172,30 @@ export function ActiveBans({ gameSlug }: Props) {
 
     return (
         <section className={styles.section}>
-            <h2 className={styles.heading}>Active bans</h2>
-            <p className={styles.description}>
+            <header className={chrome.paneHeader}>
+                <div>
+                    <div className={chrome.paneEyebrow}>Queue</div>
+                    <h2 className={chrome.paneTitle}>Active bans</h2>
+                </div>
+                <div className={chrome.paneActions}>
+                    {!loading && !error && rules.length > 0 && (
+                        <span className={chrome.paneCount}>
+                            {rules.length} active
+                        </span>
+                    )}
+                </div>
+            </header>
+            <p className={chrome.paneLede}>
                 Standing exclusions that keep a runner off this game&apos;s
-                boards. Lifting a ban reinstates their affected runs.
+                boards. Lifting one reinstates the affected runs.
             </p>
 
             {loading ? (
-                <div className={styles.loading}>
-                    <span>Loading active bans…</span>
+                <div className={styles.loading} role="status">
+                    <span className={styles.srOnly}>Loading active bans</span>
+                    <div className={styles.skeletonRow} aria-hidden="true" />
+                    <div className={styles.skeletonRow} aria-hidden="true" />
+                    <div className={styles.skeletonRow} aria-hidden="true" />
                 </div>
             ) : error ? (
                 <div className={styles.errorAlert} role="alert">
@@ -179,20 +209,37 @@ export function ActiveBans({ gameSlug }: Props) {
                         aria-hidden="true"
                     />
                     <p className={styles.emptyTitle}>No active bans</p>
-                    <p className="mb-0">
+                    <p className={styles.emptyText}>
                         This game has no standing exclusions.
                     </p>
                 </div>
             ) : (
-                <div className={styles.stack}>
-                    {rules.map((rule) => (
-                        <BanRow
-                            key={rule.ruleId}
-                            gameSlug={gameSlug}
-                            rule={rule}
-                            onLifted={onLifted}
-                        />
-                    ))}
+                <div className={styles.tableWrap}>
+                    <table className={styles.table}>
+                        <thead>
+                            <tr>
+                                <th>Runner</th>
+                                <th>Scope</th>
+                                <th>Banned by</th>
+                                <th>Date</th>
+                                <th>
+                                    <span className={styles.srOnly}>
+                                        Actions
+                                    </span>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {rules.map((rule) => (
+                                <BanRow
+                                    key={rule.ruleId}
+                                    gameSlug={gameSlug}
+                                    rule={rule}
+                                    onLifted={onLifted}
+                                />
+                            ))}
+                        </tbody>
+                    </table>
                 </div>
             )}
         </section>

--- a/app/(new-layout)/games-v2/[game]/manage/moderation/roster/roster-view.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/moderation/roster/roster-view.module.scss
@@ -57,6 +57,36 @@
     thead tr {
         background: rgba(var(--bs-body-color-rgb), 0.04);
     }
+
+    :global(.form-check-input) {
+        @include board.board-input-rules;
+    }
+}
+
+// Sortable column header: same eyebrow type as the <th> it lives in, plus
+// the interactive states the system requires on everything clickable.
+.sortBtn {
+    display: inline-flex;
+    align-items: center;
+    gap: dt.$spacing-xs;
+    border: 0;
+    background: none;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    text-transform: inherit;
+    letter-spacing: inherit;
+    cursor: pointer;
+    transition: color dt.$transition-fast;
+
+    &:hover {
+        color: var(--bs-emphasis-color);
+    }
+
+    &:focus-visible {
+        outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
+        outline-offset: 1px;
+    }
 }
 
 // Times are data: mono, tabular, right-aligned — the system's signature.

--- a/app/(new-layout)/games-v2/[game]/manage/moderation/roster/roster-view.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/moderation/roster/roster-view.tsx
@@ -77,7 +77,7 @@ function SortableTh({
         <th className={alignClass} aria-sort={active ? sort.direction : 'none'}>
             <button
                 type="button"
-                className="btn btn-link btn-sm p-0 text-decoration-none text-body fw-semibold d-inline-flex align-items-center gap-1"
+                className={styles.sortBtn}
                 onClick={() => onSort(sortKey)}
             >
                 {label}
@@ -309,13 +309,18 @@ export function RosterView({
     return (
         <div>
             <div className={consoleStyles.paneHeader}>
-                <h1 className={consoleStyles.paneTitle}>
-                    Browse runs — {gameDisplay}
-                </h1>
+                <div>
+                    <div className={consoleStyles.paneEyebrow}>Queue</div>
+                    <h1 className={consoleStyles.paneTitle}>Browse runs</h1>
+                </div>
                 <div className={consoleStyles.paneActions}>
                     <BackLink href={consoleHref} label="Back to console" />
                 </div>
             </div>
+            <p className={consoleStyles.paneLede}>
+                Every run on a {gameDisplay} board: filter, sort, and act in
+                bulk.
+            </p>
 
             <div className={styles.filters}>
                 <div className="row g-2 align-items-end">

--- a/app/(new-layout)/games-v2/[game]/manage/moderation/runner/[userId]/runner-view.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/moderation/runner/[userId]/runner-view.tsx
@@ -638,12 +638,18 @@ export function RunnerView({
                                                                 />
                                                             </td>
                                                             <td className="text-end">
-                                                                <div className="d-inline-flex gap-1">
+                                                                <div
+                                                                    className={
+                                                                        styles.rowActions
+                                                                    }
+                                                                >
                                                                     {status ===
                                                                         'pending' && (
                                                                         <button
                                                                             type="button"
-                                                                            className="btn btn-sm btn-outline-success"
+                                                                            className={
+                                                                                styles.approveBtn
+                                                                            }
                                                                             onClick={() =>
                                                                                 openRunsAction(
                                                                                     'approve',
@@ -659,7 +665,9 @@ export function RunnerView({
                                                                     )}
                                                                     <button
                                                                         type="button"
-                                                                        className="btn btn-sm btn-outline-danger"
+                                                                        className={
+                                                                            styles.removeBtn
+                                                                        }
                                                                         onClick={() =>
                                                                             openRunsAction(
                                                                                 'remove',
@@ -673,7 +681,9 @@ export function RunnerView({
                                                                         Remove…
                                                                     </button>
                                                                     <a
-                                                                        className="btn btn-sm btn-outline-secondary"
+                                                                        className={
+                                                                            styles.pillBtn
+                                                                        }
                                                                         href={`/games-v2/${encodeURIComponent(gameSlug)}/manage/run/${r.runId}`}
                                                                     >
                                                                         Open
@@ -707,7 +717,11 @@ export function RunnerView({
                                                             duration={m.timeMs}
                                                         />
                                                     </span>
-                                                    <span className="badge text-bg-secondary">
+                                                    <span
+                                                        className={
+                                                            styles.timingPill
+                                                        }
+                                                    >
                                                         {m.timing === 'gametime'
                                                             ? 'GT'
                                                             : 'RT'}
@@ -717,10 +731,16 @@ export function RunnerView({
                                                             m.verificationStatus
                                                         }
                                                     />
-                                                    <div className="ms-auto d-inline-flex gap-1">
+                                                    <div
+                                                        className={
+                                                            styles.manualActions
+                                                        }
+                                                    >
                                                         <button
                                                             type="button"
-                                                            className="btn btn-sm btn-outline-primary"
+                                                            className={
+                                                                styles.pillBtn
+                                                            }
                                                             onClick={() =>
                                                                 setDialog({
                                                                     kind: 'manual',
@@ -733,7 +753,9 @@ export function RunnerView({
                                                         </button>
                                                         <button
                                                             type="button"
-                                                            className="btn btn-sm btn-outline-danger"
+                                                            className={
+                                                                styles.removeBtn
+                                                            }
                                                             onClick={() =>
                                                                 setDeletingManualId(
                                                                     deletingManualId ===
@@ -1029,7 +1051,7 @@ export function RunnerView({
                             </span>
                         </div>
                         {modLog.length === 0 ? (
-                            <p className="text-muted small mb-0">
+                            <p className={styles.mutedSmall}>
                                 No moderation events involve this runner.
                             </p>
                         ) : (

--- a/app/(new-layout)/games-v2/[game]/manage/overview/board-overview.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/overview/board-overview.module.scss
@@ -3,8 +3,9 @@
 
 // ============================================================
 // Board overview — the console front door.
-// Same craft vocabulary as the console: border-based depth,
-// subtle surface tint, severity accents. Scannable summary first.
+// Control-room reading order: the status headline first (do I
+// need to work right now?), then the board's vitals, then the
+// deeper panels. Severity is the organizing principle.
 // ============================================================
 
 .wrap {
@@ -13,126 +14,258 @@
     gap: dt.$spacing-2xl;
 }
 
-// ---- Status line -------------------------------------------
-.statusLine {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: dt.$spacing-md;
-    font-size: dt.$font-size-sm;
-    color: var(--bs-secondary-color);
-    margin-top: calc(#{dt.$spacing-lg} * -1);
-}
-
-.statusPill {
-    @include board.board-pill;
+.publicLink {
+    @include board.board-quiet-link;
     display: inline-flex;
     align-items: center;
     gap: dt.$spacing-xs;
-}
-.statusPill.live {
-    background: color-mix(in srgb, #{dt.$accent-green} 16%, transparent);
-    color: color-mix(in srgb, #{dt.$accent-green} 78%, var(--bs-body-color));
-}
-.statusPill.setup {
-    background: color-mix(in srgb, #{dt.$accent-amber} 18%, transparent);
-    color: color-mix(in srgb, #{dt.$accent-amber} 80%, var(--bs-body-color));
-}
-.beat {
-    width: 0.5rem;
-    height: 0.5rem;
-    border-radius: 50%;
-    background: currentColor;
-}
-.sep {
-    color: var(--bs-tertiary-color);
-}
-.publicLink {
-    color: var(--bs-primary);
     text-decoration: none;
-    font-weight: 600;
-    margin-left: auto;
-    &:hover {
-        text-decoration: underline;
+    white-space: nowrap;
+}
+
+// ---- Status headline ---------------------------------------
+// The one block a moderator reads before anything else. Carries a
+// severity spine when work is waiting; sits calm and spineless when
+// the queue is empty.
+.status {
+    @include board.board-surface(dt.$spacing-xl dt.$spacing-2xl);
+    position: relative;
+    overflow: clip;
+
+    &[data-sev='high']::before,
+    &[data-sev='medium']::before,
+    &[data-sev='low']::before {
+        content: '';
+        position: absolute;
+        inset-block: 0;
+        inset-inline-start: 0;
+        width: 3px;
+    }
+    &[data-sev='high']::before {
+        background: dt.$accent-red;
+    }
+    &[data-sev='medium']::before {
+        background: dt.$accent-amber;
+    }
+    &[data-sev='low']::before {
+        background: var(--bs-secondary);
     }
 }
 
-// ---- KPI row -----------------------------------------------
-.kpis {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
-    gap: dt.$spacing-lg;
+.statusHead {
+    display: flex;
+    align-items: center;
+    gap: dt.$spacing-xl;
 }
 
-.kpi {
-    @include board.board-surface(dt.$spacing-lg);
-    border-radius: dt.$radius-md;
-    position: relative;
-    overflow: clip;
+// The focal number. Mono tabular like every count in the console.
+.statusCount {
+    @include board.mono-time;
+    font-size: dt.$font-size-display;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    line-height: 1;
+    color: var(--bs-tertiary-color);
+
+    .status[data-sev='high'] & {
+        color: dt.$accent-red;
+    }
+    .status[data-sev='medium'] & {
+        color: color-mix(in srgb, #{dt.$accent-amber} 85%, var(--bs-body-color));
+    }
+    .status[data-sev='low'] & {
+        color: var(--bs-emphasis-color);
+    }
+}
+
+.statusText {
+    min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: dt.$spacing-xs;
+    gap: 2px;
 }
-button.kpi {
-    cursor: pointer;
+
+.statusTitle {
+    font-size: dt.$font-size-xl;
+    font-weight: 700;
+    letter-spacing: -0.015em;
+    line-height: 1.1;
+    margin: 0;
+}
+
+.statusSub {
+    font-size: dt.$font-size-sm;
+    color: var(--bs-secondary-color);
+    margin: 0;
+    font-variant-numeric: tabular-nums;
+}
+
+.statusOpen {
+    @include board.board-btn-primary;
+    margin-left: auto;
+    flex-shrink: 0;
+}
+
+// ---- Queue preview rows ------------------------------------
+.previewList {
+    list-style: none;
+    margin: dt.$spacing-lg 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: dt.$spacing-sm;
+}
+
+.previewRow {
+    position: relative;
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: dt.$spacing-sm dt.$spacing-lg;
+    width: 100%;
     text-align: left;
     font: inherit;
     color: inherit;
-    transition: border-color 0.12s ease;
+    padding: dt.$spacing-sm dt.$spacing-lg;
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
+    border-left-width: 3px;
+    border-left-color: var(--bs-secondary);
+    border-radius: dt.$radius-md;
+    background: var(--bs-body-bg);
+    cursor: pointer;
+    transition: border-color dt.$transition-fast,
+        background-color dt.$transition-fast;
+
     &:hover {
-        border-color: rgba(var(--bs-border-color-rgb), 0.9);
+        background: var(--bs-tertiary-bg);
     }
     &:focus-visible {
         outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
-        outline-offset: 2px;
+        outline-offset: 1px;
+    }
+}
+
+.sevHigh {
+    border-left-color: dt.$accent-red;
+}
+.sevMedium {
+    border-left-color: dt.$accent-amber;
+}
+.sevLow {
+    border-left-color: var(--bs-secondary);
+}
+
+.previewRunner {
+    font-weight: 600;
+    font-size: dt.$font-size-sm;
+}
+
+.previewCat {
+    font-size: dt.$font-size-sm;
+    color: var(--bs-secondary-color);
+}
+
+.previewTime {
+    @include board.mono-time;
+    font-size: dt.$font-size-sm;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+}
+
+.previewSource {
+    @include board.board-eyebrow;
+    color: var(--bs-tertiary-color);
+}
+
+.previewAge {
+    margin-left: auto;
+    font-size: dt.$font-size-2xs;
+    color: var(--bs-tertiary-color);
+    white-space: nowrap;
+}
+
+.previewMore {
+    margin: dt.$spacing-sm 0 0;
+    font-size: dt.$font-size-xs;
+    color: var(--bs-tertiary-color);
+    font-variant-numeric: tabular-nums;
+}
+
+// ---- KPI band ----------------------------------------------
+// One surface, hairline-divided cells: the board's vitals as a
+// single instrument strip, not a wall of boxes.
+.kpis {
+    @include board.board-surface(0);
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+    gap: 1px;
+    background: var(
+        --board-surface-border,
+        rgba(var(--bs-border-color-rgb), 0.5)
+    );
+    overflow: clip;
+}
+
+%kpi-cell {
+    @include board.board-surface(dt.$spacing-lg dt.$spacing-xl);
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    display: flex;
+    flex-direction: column;
+    gap: dt.$spacing-xs;
+    min-width: 0;
+}
+
+.kpi {
+    @extend %kpi-cell;
+}
+
+.kpiBtn {
+    @extend %kpi-cell;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    transition: background-color dt.$transition-fast;
+
+    &:hover {
+        background: var(--bs-tertiary-bg);
+    }
+    &:focus-visible {
+        outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
+        outline-offset: -2px;
     }
 }
 
 .kpiLabel {
-    font-size: dt.$font-size-2xs;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--bs-secondary-color);
-    font-weight: 600;
+    @include board.board-eyebrow;
+    color: var(--bs-tertiary-color);
 }
+
 .kpiVal {
-    font-size: dt.$font-size-2xl;
+    @include board.mono-time;
+    font-size: dt.$font-size-xl;
     font-weight: 700;
     letter-spacing: -0.02em;
-    font-variant-numeric: tabular-nums;
     line-height: 1.1;
-
-    small {
-        font-size: dt.$font-size-md;
-        font-weight: 500;
-        color: var(--bs-tertiary-color);
-    }
 }
+
 .kpiSub {
     font-size: dt.$font-size-2xs;
     color: var(--bs-tertiary-color);
-}
-.kpiSub.up {
-    color: color-mix(in srgb, #{dt.$accent-green} 80%, var(--bs-body-color));
+    font-variant-numeric: tabular-nums;
 }
 
-// Attention KPI carries a severity spine + red numeral when non-zero.
-.kpi.flag::before {
-    content: '';
-    position: absolute;
-    inset-block: 0;
-    inset-inline-start: 0;
-    width: 3px;
-    background: dt.$accent-red;
-}
-.kpi.flag .kpiVal {
-    color: dt.$accent-red;
+.kpiSubAlert {
+    color: color-mix(in srgb, #{dt.$accent-amber} 80%, var(--bs-body-color));
+    font-weight: 600;
 }
 
 // ---- Main grid ---------------------------------------------
 .grid {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) 22rem;
+    grid-template-columns: minmax(0, 1fr) 21rem;
     gap: dt.$spacing-xl;
     align-items: start;
 
@@ -140,6 +273,7 @@ button.kpi {
         grid-template-columns: 1fr;
     }
 }
+
 .rail {
     display: flex;
     flex-direction: column;
@@ -147,121 +281,98 @@ button.kpi {
     min-width: 0;
 }
 
-// ---- Card --------------------------------------------------
+// The health card carries its own above-pane bottom margin; inside
+// the rail the column gap does the spacing.
+.railFlush {
+    margin-bottom: 0;
+}
+
+// ---- Categories card ---------------------------------------
 .card {
     @include board.board-surface(0);
-    border-radius: dt.$radius-lg;
     overflow: clip;
 }
+
 .cardHead {
     display: flex;
     align-items: baseline;
     gap: dt.$spacing-sm;
-    padding: dt.$spacing-lg dt.$spacing-xl;
-    border-bottom: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
-}
-.cardTitle {
-    font-size: dt.$font-size-md;
-    font-weight: 700;
-    margin: 0;
-}
-.cardCount {
-    font-size: dt.$font-size-sm;
-    color: var(--bs-tertiary-color);
-    @include board.mono-time;
-}
-.cardLink {
-    margin-left: auto;
-    font-size: dt.$font-size-sm;
-    font-weight: 600;
-    color: var(--bs-primary);
-    text-decoration: none;
-    background: none;
-    border: 0;
-    cursor: pointer;
-    &:hover {
-        text-decoration: underline;
-    }
-}
-.cardBody {
-    padding: dt.$spacing-lg dt.$spacing-xl;
+    padding: dt.$spacing-lg dt.$spacing-xl dt.$spacing-md;
 }
 
-// ---- Categories table --------------------------------------
-.tableScroll {
-    overflow-x: auto;
+.cardEyebrow {
+    @include board.board-eyebrow;
 }
+
+.cardCount {
+    @include board.board-section-count;
+}
+
+.cardLink {
+    @include board.board-quiet-link;
+    margin-left: auto;
+    white-space: nowrap;
+}
+
 .table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: dt.$font-size-sm;
+    @include board.board-table;
 
     th,
     td {
-        padding: dt.$spacing-md dt.$spacing-xl;
         text-align: right;
-        white-space: nowrap;
     }
     th:first-child,
     td:first-child {
         text-align: left;
+        padding-inline-start: dt.$spacing-xl;
     }
-    thead th {
-        font-size: dt.$font-size-2xs;
-        letter-spacing: 0.06em;
-        text-transform: uppercase;
-        color: var(--bs-secondary-color);
-        font-weight: 600;
-        padding-block: dt.$spacing-sm;
+    th:last-child,
+    td:last-child {
+        padding-inline-end: dt.$spacing-xl;
     }
     tbody td {
-        border-top: 1px solid rgba(var(--bs-border-color-rgb), 0.4);
+        padding-block: dt.$spacing-sm;
     }
     tbody tr {
         cursor: pointer;
     }
-    tbody tr:hover {
-        background: rgba(var(--bs-secondary-rgb), 0.06);
+    tbody tr:last-child td {
+        border-bottom: 0;
     }
-    .num {
-        font-variant-numeric: tabular-nums;
-    }
-    .muted {
-        color: var(--bs-tertiary-color);
-    }
-    .time {
-        @include board.mono-time;
-        color: var(--bs-tertiary-color);
+    tbody tr:focus-visible {
+        outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
+        outline-offset: -2px;
     }
 }
+
+.num {
+    @include board.mono-time;
+    font-size: dt.$font-size-sm;
+    white-space: nowrap;
+}
+
+.numMuted {
+    color: var(--bs-secondary-color);
+}
+
 .catName {
     font-weight: 600;
 }
-.tag {
-    display: inline-block;
-    font-size: dt.$font-size-2xs;
-    font-weight: 600;
-    padding: 0.1rem 0.45rem;
-    border-radius: dt.$radius-sm;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-}
-.tag.feat {
-    background: rgba(var(--bs-primary-rgb), 0.12);
-    color: var(--bs-primary);
-}
+
 .barCell {
     display: inline-flex;
     align-items: center;
     gap: dt.$spacing-sm;
     justify-content: flex-end;
 }
+
 .bar {
     width: 3rem;
     height: 0.3rem;
     border-radius: 3px;
     background: rgba(var(--bs-secondary-rgb), 0.18);
     overflow: hidden;
+
     i {
         display: block;
         height: 100%;
@@ -269,65 +380,114 @@ button.kpi {
         border-radius: 3px;
     }
 }
+
 .tableFoot {
     padding: dt.$spacing-md dt.$spacing-xl;
     border-top: 1px solid rgba(var(--bs-border-color-rgb), 0.4);
     font-size: dt.$font-size-sm;
     color: var(--bs-tertiary-color);
+    font-variant-numeric: tabular-nums;
 }
-.tableFoot button {
-    background: none;
-    border: 0;
-    padding: 0;
-    color: var(--bs-primary);
-    font-weight: 600;
-    cursor: pointer;
-    &:hover {
-        text-decoration: underline;
-    }
-}
-.emptyRow {
-    padding: dt.$spacing-2xl dt.$spacing-xl;
-    text-align: center;
-    color: var(--bs-tertiary-color);
+
+.tableFootLink {
+    @include board.board-quiet-link;
     font-size: dt.$font-size-sm;
 }
 
-// ---- Import & sync card ------------------------------------
-.syncRow {
+.cardEmpty {
+    @include board.board-empty;
+    padding-block: dt.$spacing-2xl;
+}
+
+.cardEmptyTitle {
+    @include board.board-empty-title;
+}
+
+// ---- Rail cards --------------------------------------------
+.railCard {
+    @include board.board-surface(dt.$spacing-lg dt.$spacing-xl);
+}
+
+.railHead {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
     gap: dt.$spacing-md;
-    padding-block: dt.$spacing-xs;
+    margin-bottom: dt.$spacing-md;
+}
+
+.railEyebrow {
+    @include board.board-eyebrow;
+}
+
+.railLink {
+    @include board.board-quiet-link;
+    white-space: nowrap;
+}
+
+// Setup progress (shown while the board isn't live yet).
+.setupMeter {
+    height: 4px;
+    border-radius: 2px;
+    background: rgba(var(--bs-border-color-rgb), 0.5);
+    overflow: hidden;
+    margin-bottom: dt.$spacing-sm;
+}
+
+.setupFill {
+    height: 100%;
+    border-radius: 2px;
+    background: var(--bs-primary);
+    transition: width dt.$transition-base;
+}
+
+.setupSub {
     font-size: dt.$font-size-sm;
-}
-.syncK {
     color: var(--bs-secondary-color);
-}
-.syncV {
-    font-weight: 600;
+    margin: 0 0 dt.$spacing-md;
     font-variant-numeric: tabular-nums;
 }
-.syncV.mono {
-    @include board.mono-time;
+
+// ---- Import & sync card ------------------------------------
+.syncStatusRow {
+    display: flex;
+    align-items: center;
+    gap: dt.$spacing-sm;
+    margin-bottom: dt.$spacing-sm;
 }
-.syncStatus {
+
+.syncPill {
+    @include board.board-pill;
     text-transform: capitalize;
+
+    &[data-status='done'] {
+        background: rgba(var(--bs-primary-rgb), 0.12);
+        color: var(--bs-primary);
+        border-color: transparent;
+    }
+    &[data-status='failed'] {
+        background: color-mix(in srgb, #{dt.$accent-red} 16%, transparent);
+        color: dt.$accent-red;
+        border-color: transparent;
+    }
+    &[data-status='running'],
+    &[data-status='queued'] {
+        background: color-mix(in srgb, #{dt.$accent-amber} 18%, transparent);
+        color: color-mix(in srgb, #{dt.$accent-amber} 80%, var(--bs-body-color));
+        border-color: transparent;
+    }
 }
-.syncStatus.done {
-    color: color-mix(in srgb, #{dt.$accent-green} 80%, var(--bs-body-color));
+
+.syncAge {
+    font-size: dt.$font-size-sm;
+    color: var(--bs-secondary-color);
+    font-variant-numeric: tabular-nums;
 }
-.syncStatus.failed {
-    color: dt.$accent-red;
-}
-.syncStatus.running {
-    color: color-mix(in srgb, #{dt.$accent-amber} 82%, var(--bs-body-color));
-}
+
 .phaseBar {
     display: flex;
     gap: dt.$spacing-xs;
-    margin: dt.$spacing-md 0 dt.$spacing-sm;
+    margin: dt.$spacing-sm 0;
 
     span {
         flex: 1;
@@ -336,170 +496,95 @@ button.kpi {
         background: rgba(var(--bs-secondary-rgb), 0.18);
     }
     span.on {
-        background: color-mix(in srgb, #{dt.$accent-green} 70%, transparent);
+        background: rgba(var(--bs-primary-rgb), 0.7);
     }
 }
+
+.syncRow {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: dt.$spacing-md;
+    padding-block: dt.$spacing-xs;
+    font-size: dt.$font-size-sm;
+}
+
+.syncK {
+    color: var(--bs-secondary-color);
+}
+
+.syncV {
+    @include board.mono-time;
+    font-size: dt.$font-size-sm;
+    font-weight: 600;
+}
+
+.changeSummary {
+    margin: dt.$spacing-sm 0 0;
+    font-size: dt.$font-size-sm;
+    color: var(--bs-body-color);
+    font-variant-numeric: tabular-nums;
+}
+
+.changeLabel {
+    @include board.board-eyebrow;
+    display: block;
+    color: var(--bs-tertiary-color);
+    margin-bottom: 2px;
+}
+
 .syncEmpty {
     font-size: dt.$font-size-sm;
     color: var(--bs-secondary-color);
     margin: 0 0 dt.$spacing-md;
 }
-.changeSummary {
-    margin: dt.$spacing-md 0 0;
-    font-size: dt.$font-size-sm;
-    color: var(--bs-body-color);
-    font-variant-numeric: tabular-nums;
-}
-.changeLabel {
-    display: block;
-    font-size: dt.$font-size-2xs;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--bs-tertiary-color);
-    font-weight: 600;
-    margin-bottom: 2px;
-}
-// The card's primary action (re-sync / first import) — filled accent so it's the
-// obvious click, with the "View details" header link left as the quiet way into
-// the manual console.
-.railBtn {
-    display: block;
-    width: 100%;
-    text-align: center;
-    padding: dt.$spacing-sm dt.$spacing-md;
-    border-radius: dt.$radius-md;
-    border: 1px solid var(--bs-primary);
-    background: var(--bs-primary);
-    color: #fff;
-    font-weight: 600;
-    font-size: dt.$font-size-sm;
-    cursor: pointer;
-    margin-top: dt.$spacing-sm;
-    &:hover:not(:disabled) {
-        filter: brightness(1.06);
-    }
-    &:disabled {
-        opacity: 0.55;
-        cursor: not-allowed;
-    }
-}
-.railHint {
-    margin: dt.$spacing-sm 0 0;
-    font-size: dt.$font-size-2xs;
-    color: var(--bs-tertiary-color);
-    text-align: center;
-}
-.railErr {
-    margin: dt.$spacing-sm 0 0;
-    font-size: dt.$font-size-2xs;
-    color: dt.$accent-red;
-    text-align: center;
-}
+
 .divider {
     height: 1px;
     background: rgba(var(--bs-border-color-rgb), 0.4);
     margin: dt.$spacing-md 0;
 }
 
-// ---- Moderators card ---------------------------------------
-.modRow {
-    display: flex;
-    align-items: center;
-    gap: dt.$spacing-md;
-    padding-block: dt.$spacing-sm;
-}
-.avatar {
-    width: 2rem;
-    height: 2rem;
-    border-radius: 50%;
-    flex: none;
-    display: grid;
-    place-items: center;
-    font-size: dt.$font-size-2xs;
-    font-weight: 700;
-    color: #fff;
-    text-transform: uppercase;
-}
-.modName {
-    font-weight: 600;
-    font-size: dt.$font-size-sm;
-}
-.modRole {
-    font-size: dt.$font-size-2xs;
-    color: var(--bs-tertiary-color);
-    text-transform: capitalize;
-}
-.modYou {
-    margin-left: auto;
-    font-size: dt.$font-size-2xs;
-    color: var(--bs-tertiary-color);
-    font-weight: 600;
-}
-.appNote {
-    margin-top: dt.$spacing-md;
-    padding: dt.$spacing-sm dt.$spacing-md;
-    border-radius: dt.$radius-md;
-    background: color-mix(in srgb, #{dt.$accent-amber} 15%, transparent);
-    color: color-mix(in srgb, #{dt.$accent-amber} 82%, var(--bs-body-color));
-    font-size: dt.$font-size-sm;
-    font-weight: 600;
+// The card's primary action (re-sync / first import).
+.railBtn {
+    @include board.board-btn-primary;
     width: 100%;
-    text-align: left;
-    border: 0;
-    cursor: pointer;
-    &:hover {
-        filter: brightness(1.05);
-    }
 }
 
-// ---- Jump-to tiles -----------------------------------------
-.jump {
-    display: flex;
-    flex-direction: column;
-    gap: dt.$spacing-md;
-}
-.jumpLabel {
-    font-size: dt.$font-size-2xs;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    color: var(--bs-secondary-color);
-    font-weight: 600;
-    margin: 0;
-}
-.tiles {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
-    gap: dt.$spacing-md;
-}
-.tile {
-    @include board.board-surface(dt.$spacing-lg);
-    border-radius: dt.$radius-md;
-    text-align: left;
-    cursor: pointer;
-    display: flex;
-    flex-direction: column;
-    gap: dt.$spacing-xs;
-    transition: border-color 0.12s ease;
-    &:hover {
-        border-color: var(--bs-primary);
-    }
-    &:focus-visible {
-        outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
-        outline-offset: 2px;
-    }
-}
-.tileTop {
-    display: flex;
-    align-items: center;
-    gap: dt.$spacing-sm;
-    color: var(--bs-primary);
-}
-.tileAction {
-    font-weight: 600;
-    font-size: dt.$font-size-sm;
-    color: var(--bs-body-color);
-}
-.tileBlurb {
+.railHint {
+    margin: dt.$spacing-sm 0 0;
     font-size: dt.$font-size-2xs;
     color: var(--bs-tertiary-color);
+    text-align: center;
+}
+
+.railErr {
+    margin: dt.$spacing-sm 0 0;
+    font-size: dt.$font-size-2xs;
+    color: dt.$accent-red;
+    text-align: center;
+}
+
+// ---- Destinations row --------------------------------------
+// One quiet line of doors; the sidebar remains the real navigation.
+.jump {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: dt.$spacing-sm dt.$spacing-xl;
+    padding-top: dt.$spacing-lg;
+    border-top: 1px solid rgba(var(--bs-border-color-rgb), 0.35);
+}
+
+.jumpLabel {
+    @include board.board-eyebrow;
+    color: var(--bs-tertiary-color);
+}
+
+.jumpLink {
+    @include board.board-quiet-link;
+    display: inline-flex;
+    align-items: center;
+    gap: dt.$spacing-xs;
+    font-size: dt.$font-size-sm;
 }

--- a/app/(new-layout)/games-v2/[game]/manage/overview/board-overview.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/overview/board-overview.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { BoxArrowUpRight } from 'react-bootstrap-icons';
+import chrome from '~src/components/console-chrome/console.module.scss';
 import { NAV_ICON } from '~src/components/console-chrome/nav-icons';
 import Link from '~src/components/link';
+import { DurationToFormatted } from '~src/components/util/datetime';
 import type { ManageCategoryRow, ManageGroup } from '~src/lib/category-mgmt';
-import { CONCEPT_TILE, type TileConceptId } from '~src/lib/console/vocabulary';
+import { CONCEPT_TILE } from '~src/lib/console/vocabulary';
 import { splitLevelBoards } from '~src/lib/levels/display';
 import type { BoardCompleteness } from '~src/lib/setup/completeness';
 import type { BoardHealth } from '~src/lib/setup/health';
@@ -22,12 +24,12 @@ import { buildOverviewStats, timeAgo, topFeaturedRows } from './overview-model';
 import { ResyncButton } from './resync-button';
 
 // The four staging phases the import worker walks (SrcImportPhase), in order —
-// drives the progress bar's filled-segment count.
+// drives the progress bar's filled-segment count while a job is running.
 const IMPORT_PHASES = ['meta', 'runs', 'matching', 'done'] as const;
 
-// Concepts the dashboard already gives a dedicated panel; everything else the
-// viewer can reach becomes a "Jump to" tile so the front door still leads
-// everywhere the sidebar does.
+// Concepts the overview already surfaces directly; everything else the viewer
+// can reach becomes a quiet destination link so nothing is unreachable from
+// the front door.
 const FEATURED_ON_DASHBOARD = new Set<NavItemId>([
     'categories',
     'moderators',
@@ -36,17 +38,18 @@ const FEATURED_ON_DASHBOARD = new Set<NavItemId>([
     'attention',
 ]);
 
-const AVATAR_HUES = [210, 160, 32, 280, 340, 130];
-function avatarStyle(name: string): { background: string } {
-    let h = 0;
-    for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) | 0;
-    const hue = AVATAR_HUES[Math.abs(h) % AVATAR_HUES.length];
-    return { background: `hsl(${hue} 55% 42%)` };
-}
+const SEV_CLASS = {
+    high: 'sevHigh',
+    medium: 'sevMedium',
+    low: 'sevLow',
+} as const;
 
-function humanRole(role: string): string {
-    return role.replace(/[-_]/g, ' ');
-}
+const SOURCE_LABEL = {
+    flag: 'flag',
+    report: 'report',
+    appeal: 'appeal',
+    self_claim: 'claim',
+} as const;
 
 /**
  * The delta a re-sync produced, shown under the import status so a moderator
@@ -93,11 +96,11 @@ interface Props {
 }
 
 /**
- * The console front door. A scannable board summary — KPIs, the featured
- * categories with their stats, board health, import status and the mod team —
- * built entirely from data the /manage page already loads (plus the latest
- * import job). Replaces the navigation-only tile grid: the sidebar is still the
- * fast path; this is the "what's the state of my board?" view.
+ * The console front door. Leads with the queue state (does anything need a
+ * moderator right now?), then the board's vitals, the category table, board
+ * health and import status — built entirely from data the /manage page
+ * already loads. The sidebar is still the fast path; this is the "what's the
+ * state of my board?" view.
  */
 export function BoardOverview({
     game,
@@ -140,45 +143,148 @@ export function BoardOverview({
         setupCompleteness.steps.find((s) => s.step === 'boards')?.status !==
             'done';
 
-    // The demoted tile grid: every reachable concept that isn't already a
-    // dashboard panel, so nothing becomes unreachable from the front door.
+    // Every reachable concept that isn't already surfaced above, as one quiet
+    // row of doors — the sidebar stays the real navigation.
     const jumpItems = navGroups
         .flatMap((g) => g.items)
         .filter(
             (it) => !FEATURED_ON_DASHBOARD.has(it.id) && it.id in CONCEPT_TILE,
         );
 
+    // Items arrive sorted severity desc, oldest first within a severity — so
+    // the first rows are exactly what a moderator should judge first.
+    const attentionTotal = stats.attention.total;
+    const topSeverity = attentionItems[0]?.severity ?? null;
+    const previewItems = attentionItems.slice(0, 3);
+    const oldestCreatedAt =
+        attentionItems.length > 0
+            ? attentionItems.reduce(
+                  (min, it) => (it.createdAt < min ? it.createdAt : min),
+                  attentionItems[0].createdAt,
+              )
+            : null;
+
+    const breakdownParts: string[] = [];
+    if (stats.attention.flags > 0) {
+        breakdownParts.push(
+            `${stats.attention.flags} flag${stats.attention.flags === 1 ? '' : 's'}`,
+        );
+    }
+    if (stats.attention.reports > 0) {
+        breakdownParts.push(
+            `${stats.attention.reports} report${stats.attention.reports === 1 ? '' : 's'}`,
+        );
+    }
+    if (stats.attention.claims > 0) {
+        breakdownParts.push(
+            `${stats.attention.claims} claim${stats.attention.claims === 1 ? '' : 's'}`,
+        );
+    }
+    const oldestAgo = timeAgo(oldestCreatedAt);
+    if (oldestAgo) breakdownParts.push(`oldest ${oldestAgo}`);
+
+    const lastSyncAgo = timeAgo(
+        syncJob?.runsImportedAt ?? syncJob?.finishedAt ?? syncJob?.createdAt,
+    );
+
     return (
         <div className={styles.wrap}>
-            <div className={styles.statusLine}>
-                {setupIncomplete ? (
-                    <span className={`${styles.statusPill} ${styles.setup}`}>
-                        <span className={styles.beat} aria-hidden />
-                        Setup in progress
-                    </span>
-                ) : (
-                    <span className={`${styles.statusPill} ${styles.live}`}>
-                        <span className={styles.beat} aria-hidden />
-                        Board is live
-                    </span>
-                )}
-                <span>
-                    {stats.featured} categor{stats.featured === 1 ? 'y' : 'ies'}
-                    {stats.categoryGroups > 0 &&
-                        ` · ${stats.categoryGroups} group${stats.categoryGroups === 1 ? '' : 's'}`}
-                    {stats.levels > 0 &&
-                        ` · ${stats.levels} level${stats.levels === 1 ? '' : 's'}`}
-                </span>
-                <Link
-                    className={styles.publicLink}
-                    href={`/games-v2/${encodeURIComponent(game.name)}`}
-                >
-                    View public page
-                    <BoxArrowUpRight size={12} aria-hidden className="ms-1" />
-                </Link>
-            </div>
+            <header className={chrome.paneHeader}>
+                <div>
+                    <div className={chrome.paneEyebrow}>Console</div>
+                    <h2 className={chrome.paneTitle}>Overview</h2>
+                </div>
+                <div className={chrome.paneActions}>
+                    <Link
+                        className={styles.publicLink}
+                        href={`/games-v2/${encodeURIComponent(game.name)}`}
+                    >
+                        View public board
+                        <BoxArrowUpRight size={12} aria-hidden />
+                    </Link>
+                </div>
+            </header>
+            <p className={chrome.paneLede}>
+                What needs a moderator, and the board's vitals.
+            </p>
 
-            {/* KPI row */}
+            {/* Status headline: the queue state before anything else. */}
+            {canModerate && (
+                <section
+                    className={styles.status}
+                    data-sev={attentionTotal > 0 ? topSeverity : undefined}
+                    aria-label="Queue status"
+                >
+                    <div className={styles.statusHead}>
+                        <span className={styles.statusCount}>
+                            {attentionTotal}
+                        </span>
+                        <div className={styles.statusText}>
+                            <h3 className={styles.statusTitle}>
+                                {attentionTotal === 0
+                                    ? 'All clear'
+                                    : 'Waiting for review'}
+                            </h3>
+                            <p className={styles.statusSub}>
+                                {attentionTotal === 0
+                                    ? 'No flags, reports or claims waiting.'
+                                    : breakdownParts.join(' · ')}
+                            </p>
+                        </div>
+                        {attentionTotal > 0 && (
+                            <button
+                                type="button"
+                                className={styles.statusOpen}
+                                onClick={() => onNavigate('attention')}
+                            >
+                                Open the queue
+                            </button>
+                        )}
+                    </div>
+                    {previewItems.length > 0 && (
+                        <ul className={styles.previewList}>
+                            {previewItems.map((item) => (
+                                <li key={item.key}>
+                                    <button
+                                        type="button"
+                                        className={`${styles.previewRow} ${styles[SEV_CLASS[item.severity]]}`}
+                                        onClick={() => onNavigate('attention')}
+                                    >
+                                        <span className={styles.previewRunner}>
+                                            {item.runnerName}
+                                        </span>
+                                        <span className={styles.previewCat}>
+                                            {item.categoryName}
+                                        </span>
+                                        <span className={styles.previewTime}>
+                                            <DurationToFormatted
+                                                duration={item.timeMs}
+                                                withMillis
+                                            />
+                                        </span>
+                                        <span className={styles.previewSource}>
+                                            {item.sources
+                                                .map((s) => SOURCE_LABEL[s])
+                                                .join(' · ')}
+                                        </span>
+                                        <span className={styles.previewAge}>
+                                            {timeAgo(item.createdAt)}
+                                        </span>
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                    {attentionTotal > previewItems.length && (
+                        <p className={styles.previewMore}>
+                            + {attentionTotal - previewItems.length} more in the
+                            queue
+                        </p>
+                    )}
+                </section>
+            )}
+
+            {/* Vitals band */}
             <div className={styles.kpis}>
                 <div className={styles.kpi}>
                     <span className={styles.kpiLabel}>Categories</span>
@@ -208,38 +314,22 @@ export function BoardOverview({
                     <span className={styles.kpiSub}>across all boards</span>
                 </div>
 
-                {canModerate && (
-                    <button
-                        type="button"
-                        className={`${styles.kpi} ${stats.attention.total > 0 ? styles.flag : ''}`}
-                        onClick={() => onNavigate('attention')}
-                    >
-                        <span className={styles.kpiLabel}>Needs attention</span>
-                        <span className={styles.kpiVal}>
-                            {stats.attention.total}
-                        </span>
-                        <span className={styles.kpiSub}>
-                            {stats.attention.total === 0
-                                ? 'nothing waiting'
-                                : `${stats.attention.flags} flags · ${stats.attention.reports} reports · ${stats.attention.claims} claims`}
-                        </span>
-                    </button>
-                )}
-
                 {showModerators && (
                     <button
                         type="button"
-                        className={styles.kpi}
+                        className={styles.kpiBtn}
                         onClick={() => onNavigate('moderators')}
                     >
                         <span className={styles.kpiLabel}>Moderators</span>
                         <span className={styles.kpiVal}>
                             {stats.moderatorCount}
                         </span>
-                        <span className={styles.kpiSub}>
+                        <span
+                            className={`${styles.kpiSub} ${pendingApplications > 0 ? styles.kpiSubAlert : ''}`}
+                        >
                             {pendingApplications > 0
                                 ? `${pendingApplications} application${pendingApplications === 1 ? '' : 's'} waiting`
-                                : 'team'}
+                                : 'on the team'}
                         </span>
                     </button>
                 )}
@@ -247,16 +337,12 @@ export function BoardOverview({
                 {showImport && (
                     <button
                         type="button"
-                        className={styles.kpi}
+                        className={styles.kpiBtn}
                         onClick={() => onNavigate('import')}
                     >
-                        <span className={styles.kpiLabel}>Last import</span>
+                        <span className={styles.kpiLabel}>Last sync</span>
                         <span className={styles.kpiVal}>
-                            {timeAgo(
-                                syncJob?.runsImportedAt ??
-                                    syncJob?.finishedAt ??
-                                    syncJob?.createdAt,
-                            ) ?? 'Never'}
+                            {lastSyncAgo ?? 'Never'}
                         </span>
                         <span className={styles.kpiSub}>
                             {syncJob ? syncJob.status : 'no import yet'}
@@ -270,97 +356,92 @@ export function BoardOverview({
                 {/* Categories */}
                 <section className={styles.card}>
                     <header className={styles.cardHead}>
-                        <h2 className={styles.cardTitle}>Categories</h2>
+                        <h3 className={styles.cardEyebrow}>Categories</h3>
                         <span className={styles.cardCount}>
-                            {stats.featured} on board
+                            {stats.featured}
                         </span>
                         <button
                             type="button"
                             className={styles.cardLink}
                             onClick={() => onNavigate('categories')}
                         >
-                            Manage →
+                            Manage
                         </button>
                     </header>
                     {topRows.length === 0 ? (
-                        <p className={styles.emptyRow}>
-                            No categories on the board yet.
-                        </p>
+                        <div className={styles.cardEmpty}>
+                            <p className={styles.cardEmptyTitle}>
+                                No categories on the board yet
+                            </p>
+                        </div>
                     ) : (
                         <>
-                            <div className={styles.tableScroll}>
-                                <table className={styles.table}>
-                                    <thead>
-                                        <tr>
-                                            <th>Category</th>
-                                            <th>Status</th>
-                                            <th>Finished runs</th>
-                                            <th>Runners</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {topRows.map((r) => (
-                                            <tr
-                                                key={r.id}
-                                                onClick={() =>
-                                                    onEditCategory(r.id)
+                            <table className={styles.table}>
+                                <thead>
+                                    <tr>
+                                        <th>Category</th>
+                                        <th>Finished runs</th>
+                                        <th>Runners</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {topRows.map((r) => (
+                                        <tr
+                                            key={r.id}
+                                            tabIndex={0}
+                                            onClick={() => onEditCategory(r.id)}
+                                            onKeyDown={(e) => {
+                                                if (
+                                                    e.key === 'Enter' ||
+                                                    e.key === ' '
+                                                ) {
+                                                    e.preventDefault();
+                                                    onEditCategory(r.id);
                                                 }
-                                            >
-                                                <td>
-                                                    <span
-                                                        className={
-                                                            styles.catName
-                                                        }
-                                                    >
-                                                        {r.display}
-                                                    </span>
-                                                </td>
-                                                <td>
-                                                    <span
-                                                        className={`${styles.tag} ${styles.feat}`}
-                                                    >
-                                                        Featured
-                                                    </span>
-                                                </td>
-                                                <td className={styles.num}>
-                                                    <span
-                                                        className={
-                                                            styles.barCell
-                                                        }
-                                                    >
-                                                        <span
-                                                            className={
-                                                                styles.bar
-                                                            }
-                                                            aria-hidden
-                                                        >
-                                                            <i
-                                                                style={{
-                                                                    width: `${Math.round((r.totalFinishedAttemptCount / maxRuns) * 100)}%`,
-                                                                }}
-                                                            />
-                                                        </span>
-                                                        {r.totalFinishedAttemptCount.toLocaleString()}
-                                                    </span>
-                                                </td>
-                                                <td
-                                                    className={`${styles.num} ${styles.muted}`}
+                                            }}
+                                        >
+                                            <td>
+                                                <span
+                                                    className={styles.catName}
                                                 >
-                                                    {r.uniqueRunners.toLocaleString()}
-                                                </td>
-                                            </tr>
-                                        ))}
-                                    </tbody>
-                                </table>
-                            </div>
+                                                    {r.display}
+                                                </span>
+                                            </td>
+                                            <td className={styles.num}>
+                                                <span
+                                                    className={styles.barCell}
+                                                >
+                                                    <span
+                                                        className={styles.bar}
+                                                        aria-hidden
+                                                    >
+                                                        <i
+                                                            style={{
+                                                                width: `${Math.round((r.totalFinishedAttemptCount / maxRuns) * 100)}%`,
+                                                            }}
+                                                        />
+                                                    </span>
+                                                    {r.totalFinishedAttemptCount.toLocaleString()}
+                                                </span>
+                                            </td>
+                                            <td
+                                                className={`${styles.num} ${styles.numMuted}`}
+                                            >
+                                                {r.uniqueRunners.toLocaleString()}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
                             {remaining > 0 && (
                                 <div className={styles.tableFoot}>
                                     + {remaining} more featured ·{' '}
                                     <button
                                         type="button"
+                                        className={styles.tableFootLink}
                                         onClick={() => onNavigate('categories')}
                                     >
-                                        See all categories →
+                                        See all categories
                                     </button>
                                 </div>
                             )}
@@ -368,106 +449,76 @@ export function BoardOverview({
                     )}
                 </section>
 
-                {/* Rail */}
+                {/* Rail: health / setup progress + import status */}
                 <div className={styles.rail}>
-                    {!setupIncomplete && boardHealth && (
-                        <BoardHealthCard
-                            gameSlug={game.name}
-                            health={boardHealth}
-                        />
+                    {setupIncomplete && setupCompleteness ? (
+                        <section className={styles.railCard}>
+                            <header className={styles.railHead}>
+                                <h3 className={styles.railEyebrow}>
+                                    Setup progress
+                                </h3>
+                            </header>
+                            <div className={styles.setupMeter} aria-hidden>
+                                <div
+                                    className={styles.setupFill}
+                                    style={{
+                                        width: `${Math.round((setupCompleteness.doneCount / Math.max(1, setupCompleteness.totalCount)) * 100)}%`,
+                                    }}
+                                />
+                            </div>
+                            <p className={styles.setupSub}>
+                                {setupCompleteness.doneCount} of{' '}
+                                {setupCompleteness.totalCount} steps done
+                            </p>
+                            <button
+                                type="button"
+                                className={styles.railBtn}
+                                onClick={() => onNavigate('setup')}
+                            >
+                                Continue setup
+                            </button>
+                        </section>
+                    ) : (
+                        boardHealth && (
+                            <BoardHealthCard
+                                gameSlug={game.name}
+                                health={boardHealth}
+                                className={styles.railFlush}
+                            />
+                        )
                     )}
 
                     {showImport && (
-                        <section className={styles.card}>
-                            <header className={styles.cardHead}>
-                                <h2 className={styles.cardTitle}>
+                        <section className={styles.railCard}>
+                            <header className={styles.railHead}>
+                                <h3 className={styles.railEyebrow}>
                                     Import &amp; sync
-                                </h2>
+                                </h3>
                                 <button
                                     type="button"
-                                    className={styles.cardLink}
+                                    className={styles.railLink}
                                     onClick={() => onNavigate('import')}
                                 >
-                                    View details →
+                                    Details
                                 </button>
                             </header>
-                            <div className={styles.cardBody}>
-                                {syncJob ? (
-                                    <>
-                                        <div className={styles.syncRow}>
-                                            <span className={styles.syncK}>
-                                                Status
+                            {syncJob ? (
+                                <>
+                                    <div className={styles.syncStatusRow}>
+                                        <span
+                                            className={styles.syncPill}
+                                            data-status={syncJob.status}
+                                        >
+                                            {syncJob.status}
+                                        </span>
+                                        {lastSyncAgo && (
+                                            <span className={styles.syncAge}>
+                                                {lastSyncAgo}
                                             </span>
-                                            <span
-                                                className={`${styles.syncV} ${styles.syncStatus} ${styles[syncJob.status] ?? ''}`}
-                                            >
-                                                {syncJob.status}
-                                            </span>
-                                        </div>
-                                        <div className={styles.syncRow}>
-                                            <span className={styles.syncK}>
-                                                Last activity
-                                            </span>
-                                            <span className={styles.syncV}>
-                                                {timeAgo(
-                                                    syncJob.runsImportedAt ??
-                                                        syncJob.finishedAt ??
-                                                        syncJob.createdAt,
-                                                ) ?? '—'}
-                                            </span>
-                                        </div>
-                                        <div className={styles.syncRow}>
-                                            <span className={styles.syncK}>
-                                                Players matched
-                                            </span>
-                                            <span
-                                                className={`${styles.syncV} ${styles.mono}`}
-                                            >
-                                                {syncJob.playersMatchedCount.toLocaleString()}
-                                            </span>
-                                        </div>
-                                        <div className={styles.syncRow}>
-                                            <span className={styles.syncK}>
-                                                Players unmatched
-                                            </span>
-                                            <span
-                                                className={`${styles.syncV} ${styles.mono}`}
-                                            >
-                                                {Math.max(
-                                                    0,
-                                                    syncJob.playersCount -
-                                                        syncJob.playersMatchedCount,
-                                                ).toLocaleString()}
-                                            </span>
-                                        </div>
-                                        {syncJob.runsImportedAt && (
-                                            <>
-                                                <div className={styles.syncRow}>
-                                                    <span
-                                                        className={styles.syncK}
-                                                    >
-                                                        Runs matched
-                                                    </span>
-                                                    <span
-                                                        className={`${styles.syncV} ${styles.mono}`}
-                                                    >
-                                                        {syncJob.importedRunsCount.toLocaleString()}
-                                                    </span>
-                                                </div>
-                                                <div className={styles.syncRow}>
-                                                    <span
-                                                        className={styles.syncK}
-                                                    >
-                                                        Runs unmatched
-                                                    </span>
-                                                    <span
-                                                        className={`${styles.syncV} ${styles.mono}`}
-                                                    >
-                                                        {syncJob.importSkippedCount.toLocaleString()}
-                                                    </span>
-                                                </div>
-                                            </>
                                         )}
+                                    </div>
+                                    {(syncJob.status === 'queued' ||
+                                        syncJob.status === 'running') && (
                                         <div
                                             className={styles.phaseBar}
                                             aria-hidden
@@ -489,139 +540,87 @@ export function BoardOverview({
                                                 );
                                             })}
                                         </div>
-                                        {syncJob.changeSummary && (
-                                            <ChangeSummaryLine
-                                                summary={syncJob.changeSummary}
-                                            />
-                                        )}
-                                    </>
-                                ) : (
-                                    <p className={styles.syncEmpty}>
-                                        No import has been run for this board
-                                        yet.
-                                    </p>
-                                )}
-                                <div className={styles.divider} />
-                                {syncJob ? (
-                                    <ResyncButton
-                                        gameId={game.id}
-                                        gameSlug={game.name}
-                                        lastJobCreatedAt={syncJob.createdAt}
-                                        running={
-                                            syncJob.status === 'queued' ||
-                                            syncJob.status === 'running'
-                                        }
-                                        bypassCooldown={isAdmin}
-                                        onStarted={() => onNavigate('import')}
-                                    />
-                                ) : (
-                                    <button
-                                        type="button"
-                                        className={styles.railBtn}
-                                        onClick={() => onNavigate('import')}
-                                    >
-                                        Run import
-                                    </button>
-                                )}
-                            </div>
-                        </section>
-                    )}
-
-                    {showModerators && (
-                        <section className={styles.card}>
-                            <header className={styles.cardHead}>
-                                <h2 className={styles.cardTitle}>Moderators</h2>
-                                <span className={styles.cardCount}>
-                                    {moderators.length}
-                                </span>
+                                    )}
+                                    <div className={styles.syncRow}>
+                                        <span className={styles.syncK}>
+                                            Players matched
+                                        </span>
+                                        <span className={styles.syncV}>
+                                            {syncJob.playersMatchedCount.toLocaleString()}
+                                            {' / '}
+                                            {syncJob.playersCount.toLocaleString()}
+                                        </span>
+                                    </div>
+                                    {syncJob.runsImportedAt && (
+                                        <div className={styles.syncRow}>
+                                            <span className={styles.syncK}>
+                                                Runs matched
+                                            </span>
+                                            <span className={styles.syncV}>
+                                                {syncJob.importedRunsCount.toLocaleString()}
+                                                {syncJob.importSkippedCount > 0
+                                                    ? ` (${syncJob.importSkippedCount.toLocaleString()} skipped)`
+                                                    : ''}
+                                            </span>
+                                        </div>
+                                    )}
+                                    {syncJob.changeSummary && (
+                                        <ChangeSummaryLine
+                                            summary={syncJob.changeSummary}
+                                        />
+                                    )}
+                                </>
+                            ) : (
+                                <p className={styles.syncEmpty}>
+                                    No import has been run for this board yet.
+                                </p>
+                            )}
+                            <div className={styles.divider} />
+                            {syncJob ? (
+                                <ResyncButton
+                                    gameId={game.id}
+                                    gameSlug={game.name}
+                                    lastJobCreatedAt={syncJob.createdAt}
+                                    running={
+                                        syncJob.status === 'queued' ||
+                                        syncJob.status === 'running'
+                                    }
+                                    bypassCooldown={isAdmin}
+                                    onStarted={() => onNavigate('import')}
+                                />
+                            ) : (
                                 <button
                                     type="button"
-                                    className={styles.cardLink}
-                                    onClick={() => onNavigate('moderators')}
+                                    className={styles.railBtn}
+                                    onClick={() => onNavigate('import')}
                                 >
-                                    Manage →
+                                    Run import
                                 </button>
-                            </header>
-                            <div className={styles.cardBody}>
-                                {moderators.slice(0, 4).map((m) => (
-                                    <div
-                                        key={m.assignmentId}
-                                        className={styles.modRow}
-                                    >
-                                        <span
-                                            className={styles.avatar}
-                                            style={avatarStyle(m.username)}
-                                            aria-hidden
-                                        >
-                                            {m.username.slice(0, 2)}
-                                        </span>
-                                        <span>
-                                            <span className={styles.modName}>
-                                                {m.username}
-                                            </span>
-                                            <br />
-                                            <span className={styles.modRole}>
-                                                {humanRole(m.role)}
-                                            </span>
-                                        </span>
-                                    </div>
-                                ))}
-                                {moderators.length > 4 && (
-                                    <div className={styles.modRole}>
-                                        + {moderators.length - 4} more
-                                    </div>
-                                )}
-                                {moderators.length === 0 && (
-                                    <p className={styles.syncEmpty}>
-                                        No moderators yet.
-                                    </p>
-                                )}
-                                {pendingApplications > 0 && (
-                                    <button
-                                        type="button"
-                                        className={styles.appNote}
-                                        onClick={() => onNavigate('moderators')}
-                                    >
-                                        {pendingApplications} application
-                                        {pendingApplications === 1 ? '' : 's'}{' '}
-                                        waiting — review
-                                    </button>
-                                )}
-                            </div>
+                            )}
                         </section>
                     )}
                 </div>
             </div>
 
-            {/* Jump to */}
+            {/* Other destinations: one quiet row, not a wall of boxes. */}
             {jumpItems.length > 0 && (
-                <section className={styles.jump} aria-label="Jump to">
-                    <h3 className={styles.jumpLabel}>Jump to</h3>
-                    <div className={styles.tiles}>
-                        {jumpItems.map((item) => {
-                            const Icon = NAV_ICON[item.id];
-                            const tile = CONCEPT_TILE[item.id as TileConceptId];
-                            return (
-                                <button
-                                    key={item.id}
-                                    type="button"
-                                    className={styles.tile}
-                                    onClick={() => onNavigate(item.id)}
-                                >
-                                    <span className={styles.tileTop}>
-                                        <Icon size={18} aria-hidden />
-                                    </span>
-                                    <span className={styles.tileAction}>
-                                        {tile.action}
-                                    </span>
-                                    <span className={styles.tileBlurb}>
-                                        {tile.blurb}
-                                    </span>
-                                </button>
-                            );
-                        })}
-                    </div>
-                </section>
+                <nav className={styles.jump} aria-label="Also in this console">
+                    <span className={styles.jumpLabel}>Also here</span>
+                    {jumpItems.map((item) => {
+                        const Icon = NAV_ICON[item.id];
+                        return (
+                            <button
+                                key={item.id}
+                                type="button"
+                                className={styles.jumpLink}
+                                onClick={() => onNavigate(item.id)}
+                            >
+                                <Icon size={14} aria-hidden />
+                                {item.label}
+                            </button>
+                        );
+                    })}
+                </nav>
             )}
         </div>
     );

--- a/app/(new-layout)/games-v2/[game]/manage/src-import/commit-panel.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/src-import/commit-panel.tsx
@@ -391,6 +391,14 @@ export function CommitPanel({ job, gameId, gameSlug, onChanged }: Props) {
 
     return (
         <section className={styles.commitCard} aria-label="Commit to therun.gg">
+            <div className={styles.commitHead}>
+                <span className={styles.commitEyebrow}>Commit</span>
+                <h3 className={styles.commitTitle}>Write to the live board</h3>
+                <p className={styles.commitLede}>
+                    Everything above is a dry run. The actions here change the
+                    live board.
+                </p>
+            </div>
             {vm.showPlanPlaceholder && (
                 <PlanPreview
                     gameId={gameId}
@@ -427,7 +435,7 @@ export function CommitPanel({ job, gameId, gameSlug, onChanged }: Props) {
                     <div className={styles.stack}>
                         <p className={styles.muted}>
                             “Only use the speedrun.com leaderboard” is on. The
-                            SRC-only reconcile is not running — start it
+                            SRC-only reconcile is not running. Start it
                             manually.
                         </p>
                         <button
@@ -445,7 +453,7 @@ export function CommitPanel({ job, gameId, gameSlug, onChanged }: Props) {
                         role="status"
                         aria-live="polite"
                     >
-                        “Only use the speedrun.com leaderboard” is on —
+                        “Only use the speedrun.com leaderboard” is on:
                         reconciling the board will start automatically.
                     </p>
                 ))}

--- a/app/(new-layout)/games-v2/[game]/manage/src-import/import-options.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/src-import/import-options.tsx
@@ -68,7 +68,7 @@ const TOGGLES: Array<{ key: ToggleKey; label: string; hint: string }> = [
     {
         key: 'setMinTimeFloor',
         label: 'Set a minimum-time floor',
-        hint: 'Flag impossibly-fast runs — below 90% of the fastest imported time.',
+        hint: 'Flag impossibly-fast runs (below 90% of the fastest imported time).',
     },
 ];
 

--- a/app/(new-layout)/games-v2/[game]/manage/src-import/plan-preview.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/src-import/plan-preview.tsx
@@ -204,36 +204,45 @@ export function PlanPreview({ gameId, gameSlug, jobId, onPlanLoaded }: Props) {
 
     return (
         <div className={styles.stack}>
-            <div className={styles.counters}>
-                {ACTIONS.map((action) => (
-                    <Counter
-                        key={`categories-${action}`}
-                        label={`Categories: ${action}`}
-                        value={categoryCounts[action]}
-                    />
-                ))}
-                {ACTIONS.map((action) => (
-                    <Counter
-                        key={`levels-${action}`}
-                        label={`Levels: ${action}`}
-                        value={levelCounts[action]}
-                    />
-                ))}
-                {ACTIONS.map((action) => (
-                    <Counter
-                        key={`variables-${action}`}
-                        label={`Variables: ${action}`}
-                        value={variableCounts[action]}
-                    />
-                ))}
+            <div className={styles.band}>
+                <p className={styles.bandLabel}>Configuration plan</p>
+                <div className={styles.counters}>
+                    {ACTIONS.map((action) => (
+                        <Counter
+                            key={`categories-${action}`}
+                            label={`Categories: ${action}`}
+                            value={categoryCounts[action]}
+                        />
+                    ))}
+                    {ACTIONS.map((action) => (
+                        <Counter
+                            key={`levels-${action}`}
+                            label={`Levels: ${action}`}
+                            value={levelCounts[action]}
+                        />
+                    ))}
+                    {ACTIONS.map((action) => (
+                        <Counter
+                            key={`variables-${action}`}
+                            label={`Variables: ${action}`}
+                            value={variableCounts[action]}
+                        />
+                    ))}
+                </div>
             </div>
-            <div className={styles.counters}>
-                <Counter label="Runs total" value={plan.runs.total} />
-                <Counter label="Verified" value={plan.runs.byStatus.verified} />
-                <Counter label="New" value={plan.runs.byStatus.new} />
-                <Counter label="Guests" value={plan.runs.guests} />
-                <Counter label="Matched" value={plan.runs.matched} />
-                <Counter label="Unmappable" value={plan.runs.unmappable} />
+            <div className={styles.band}>
+                <p className={styles.bandLabel}>Runs to import</p>
+                <div className={styles.counters}>
+                    <Counter label="Runs total" value={plan.runs.total} />
+                    <Counter
+                        label="Verified"
+                        value={plan.runs.byStatus.verified}
+                    />
+                    <Counter label="New" value={plan.runs.byStatus.new} />
+                    <Counter label="Guests" value={plan.runs.guests} />
+                    <Counter label="Matched" value={plan.runs.matched} />
+                    <Counter label="Unmappable" value={plan.runs.unmappable} />
+                </div>
             </div>
 
             {hasConflicts ? (
@@ -244,7 +253,7 @@ export function PlanPreview({ gameId, gameSlug, jobId, onPlanLoaded }: Props) {
                                 ? '1 item blocks this import'
                                 : `${plan.conflicts.length} items block this import`}
                             . Each names a category, level, or variable that
-                            can’t be imported as-is — usually because it points
+                            can’t be imported as-is, usually because it points
                             at something excluded from this import. Apply stays
                             disabled until they’re cleared.
                         </p>

--- a/app/(new-layout)/games-v2/[game]/manage/src-import/review-tabs.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/src-import/review-tabs.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { Dash } from 'react-bootstrap-icons';
 import { getFormattedString } from '~src/components/util/datetime';
 import type {
     Paged,
@@ -73,7 +74,7 @@ export function ReviewTabs({
                 options={TABS}
                 onChange={(v) => setTab(v as Tab)}
             />
-            <div style={{ marginTop: '0.75rem' }}>
+            <div className={styles.tabBody}>
                 {tab === 'categories' && <CategoriesTab state={categories} />}
                 {tab === 'levels' && <LevelsTab state={levels} />}
                 {tab === 'variables' && (
@@ -290,7 +291,13 @@ function LevelsTab({ state }: { state: LoadState<SrcImportLevel[]> }) {
 
 function Rules({ text }: { text: string | null }) {
     const [open, setOpen] = useState(false);
-    if (!text) return <span className={styles.muted}>—</span>;
+    if (!text) {
+        return (
+            <span className={styles.muted}>
+                <Dash size={16} aria-hidden />
+            </span>
+        );
+    }
     if (text.length <= 140 || open) {
         return <div className={styles.rules}>{text}</div>;
     }
@@ -299,7 +306,7 @@ function Rules({ text }: { text: string | null }) {
             {text.slice(0, 140)}…{' '}
             <button
                 type="button"
-                className="btn btn-link btn-sm p-0 align-baseline"
+                className={styles.moreLink}
                 onClick={() => setOpen(true)}
             >
                 more
@@ -400,28 +407,27 @@ function VariablesTab({
                                             </div>
                                         </td>
                                         <td>
-                                            {v.values.map((val) => (
-                                                <span
-                                                    key={val.id}
-                                                    className={`${styles.pill} ${
-                                                        val.id ===
-                                                        v.defaultValueId
-                                                            ? styles.pillPrimary
-                                                            : ''
-                                                    }`}
-                                                    style={{
-                                                        marginRight: '0.25rem',
-                                                    }}
-                                                    title={
-                                                        val.id ===
-                                                        v.defaultValueId
-                                                            ? 'default'
-                                                            : undefined
-                                                    }
-                                                >
-                                                    {val.label}
-                                                </span>
-                                            ))}
+                                            <div className={styles.pillRow}>
+                                                {v.values.map((val) => (
+                                                    <span
+                                                        key={val.id}
+                                                        className={`${styles.pill} ${
+                                                            val.id ===
+                                                            v.defaultValueId
+                                                                ? styles.pillPrimary
+                                                                : ''
+                                                        }`}
+                                                        title={
+                                                            val.id ===
+                                                            v.defaultValueId
+                                                                ? 'default'
+                                                                : undefined
+                                                        }
+                                                    >
+                                                        {val.label}
+                                                    </span>
+                                                ))}
+                                            </div>
                                         </td>
                                     </tr>
                                 ))}
@@ -537,7 +543,11 @@ function PlayerRow({ p }: { p: SrcImportPlayer }) {
                 )}
             </td>
             <td>
-                {p.therunUsername ?? <span className={styles.muted}>—</span>}
+                {p.therunUsername ?? (
+                    <span className={styles.muted}>
+                        <Dash size={16} aria-hidden />
+                    </span>
+                )}
             </td>
             <td>
                 <span className={`${styles.pill} ${pill}`}>
@@ -586,7 +596,7 @@ function RunsTab({
     return (
         <>
             <div className={styles.toolbar}>
-                <label className={styles.field} style={{ flex: '0 1 auto' }}>
+                <label className={styles.field}>
                     <span className={styles.label}>Category</span>
                     <select
                         className={styles.select}
@@ -620,10 +630,7 @@ function RunsTab({
                     </select>
                 </label>
                 {levels.length > 0 && selectedType !== 'per-game' && (
-                    <label
-                        className={styles.field}
-                        style={{ flex: '0 1 auto' }}
-                    >
+                    <label className={styles.field}>
                         <span className={styles.label}>Level</span>
                         <select
                             className={styles.select}
@@ -744,8 +751,7 @@ function RunRow({
                         {runPlayerLabel(p)}
                         {'twitchLogin' in p && p.twitchLogin && (
                             <span
-                                className={styles.muted}
-                                style={{ marginLeft: '0.25rem' }}
+                                className={`${styles.muted} ${styles.gapLeft}`}
                                 title="Twitch login on speedrun.com"
                             >
                                 (twitch: {p.twitchLogin})
@@ -753,8 +759,7 @@ function RunRow({
                         )}
                         {'therunUsername' in p && p.therunUsername && (
                             <span
-                                className={`${styles.pill} ${styles.pillPrimary}`}
-                                style={{ marginLeft: '0.25rem' }}
+                                className={`${styles.pill} ${styles.pillPrimary} ${styles.gapLeft}`}
                                 title="Matched therun.gg user"
                             >
                                 {p.therunUsername}
@@ -824,7 +829,7 @@ function Pager({
         <div className={styles.pager}>
             <button
                 type="button"
-                className="btn btn-sm btn-outline-secondary"
+                className={styles.pagerBtn}
                 disabled={page <= 1}
                 onClick={() => onPage(page - 1)}
             >
@@ -835,7 +840,7 @@ function Pager({
             </span>
             <button
                 type="button"
-                className="btn btn-sm btn-outline-secondary"
+                className={styles.pagerBtn}
                 disabled={page >= pages}
                 onClick={() => onPage(page + 1)}
             >

--- a/app/(new-layout)/games-v2/[game]/manage/src-import/src-import-pane.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/src-import/src-import-pane.tsx
@@ -7,11 +7,11 @@ import {
     useState,
     useTransition,
 } from 'react';
+import { BoxArrowUpRight } from 'react-bootstrap-icons';
 import consoleStyles from '~src/components/console-chrome/console.module.scss';
 import { CONCEPT_LABEL } from '~src/lib/console/vocabulary';
 import type { SrcImportJob } from '../../../../../../types/src-import.types';
 import { InlineError } from '../shared/form-kit';
-import kit from '../shared/form-kit.module.scss';
 import { CommitPanel } from './commit-panel';
 import { ReviewTabs } from './review-tabs';
 import styles from './src-import.module.scss';
@@ -86,22 +86,25 @@ export function SrcImportPane({ gameId, gameSlug, gameDisplay }: Props) {
     return (
         <div className={consoleStyles.surface}>
             <div className={consoleStyles.paneHeader}>
-                <h2 className={consoleStyles.paneTitle}>
-                    {CONCEPT_LABEL.import}
-                </h2>
+                <div>
+                    <div className={consoleStyles.paneEyebrow}>Game</div>
+                    <h2 className={consoleStyles.paneTitle}>
+                        {CONCEPT_LABEL.import}
+                    </h2>
+                </div>
             </div>
             <p className={consoleStyles.paneLede}>
-                Fetch the {gameDisplay} board from speedrun.com — categories,
-                subcategories and filters, runs, and players — and review it
-                here before anything is written.
+                Fetch the {gameDisplay} board from speedrun.com (categories,
+                subcategories and filters, runs, players) and review it here
+                before anything is written.
             </p>
 
             <div className={styles.stack}>
-                <div className={`${styles.callout} ${styles.calloutWarn}`}>
-                    Fetching and reviewing the board below is a dry run —
-                    nothing is written yet. Once the import finishes, the commit
-                    controls under the review tabs DO write to the live board.
-                </div>
+                <p className={styles.note}>
+                    Fetching and reviewing the board below is a dry run: nothing
+                    is written yet. Only the commit controls at the bottom write
+                    to the live board.
+                </p>
 
                 <form className={styles.form} onSubmit={submit}>
                     <div className={styles.field}>
@@ -124,20 +127,20 @@ export function SrcImportPane({ gameId, gameSlug, gameDisplay }: Props) {
                                 disabled={pending || inFlight}
                                 required
                             />
+                            <button
+                                type="submit"
+                                className={styles.fetchBtn}
+                                disabled={pending || inFlight || !url}
+                            >
+                                {pending ? 'Starting…' : 'Fetch board'}
+                            </button>
                         </span>
                     </div>
-                    <button
-                        type="submit"
-                        className={kit.saveBtn}
-                        disabled={pending || inFlight || !url}
-                    >
-                        {pending ? 'Starting…' : 'Fetch board'}
-                    </button>
                 </form>
                 {submitError && <InlineError>{submitError}</InlineError>}
                 {inFlight && (
                     <p className={styles.muted}>
-                        An import is already running for this game — wait for it
+                        An import is already running for this game. Wait for it
                         to finish before starting another.
                     </p>
                 )}
@@ -209,16 +212,23 @@ function JobCard({ job }: { job: SrcImportJob }) {
                     target="_blank"
                     rel="noreferrer noopener"
                 >
-                    {job.srcUrl}
+                    View on speedrun.com
+                    <BoxArrowUpRight size={12} aria-hidden />
                 </a>
+                <span className={styles.jobTimes}>
+                    Started {job.startedAt ? fmtDate(job.startedAt) : '—'}
+                    {job.finishedAt
+                        ? ` · finished ${fmtDate(job.finishedAt)}`
+                        : ''}
+                </span>
             </div>
             {inFlight && (
                 <>
                     <JobProgress job={job} />
                     <p className={styles.muted}>
                         Phase: {PHASE_LABEL[job.phase]}. speedrun.com is rate
-                        limited, so large boards take a while — this page
-                        updates on its own.
+                        limited, so large boards take a while. This page updates
+                        on its own.
                     </p>
                 </>
             )}
@@ -238,8 +248,8 @@ function JobCard({ job }: { job: SrcImportJob }) {
                 <Counter label="API requests" value={job.requestsMade} />
             </div>
             {job.changeSummary && (
-                <>
-                    <p className={styles.muted}>What this import changed</p>
+                <div className={styles.changedBand}>
+                    <p className={styles.bandLabel}>What this import changed</p>
                     <div className={styles.counters}>
                         <Counter
                             label="Runs added"
@@ -258,12 +268,8 @@ function JobCard({ job }: { job: SrcImportJob }) {
                             value={job.changeSummary.archived}
                         />
                     </div>
-                </>
+                </div>
             )}
-            <p className={styles.muted}>
-                Started {job.startedAt ? fmtDate(job.startedAt) : '—'}
-                {job.finishedAt ? ` · finished ${fmtDate(job.finishedAt)}` : ''}
-            </p>
         </section>
     );
 }

--- a/app/(new-layout)/games-v2/[game]/manage/src-import/src-import.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/src-import/src-import.module.scss
@@ -1,8 +1,9 @@
 @use '../../../../styles/design-tokens' as dt;
 @use '../../../../styles/board' as board;
 
-// speedrun.com import pane — same control-room vocabulary as the
-// reassignment wizards: bordered surfaces, token spacing, quiet accents.
+// speedrun.com import pane — a staged instrument: fetch controls, one
+// status/stat surface for the job, review tables in board vocabulary,
+// and a clearly fenced commit zone at the bottom.
 
 $rail: 3px;
 
@@ -16,26 +17,34 @@ $rail: 3px;
     gap: dt.$spacing-xl;
 }
 
+// Quiet dry-run note (the console's noteInfo recipe, local so this module
+// doesn't reach into console-chrome for spacing overrides).
+.note {
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
+    border-left: $rail solid var(--bs-primary);
+    border-radius: dt.$radius-md;
+    background: var(--bs-body-bg);
+    padding: dt.$spacing-sm dt.$spacing-lg;
+    font-size: dt.$font-size-sm;
+    color: var(--bs-secondary-color);
+    margin: 0;
+}
+
+// ---- Fetch controls: one composed input row ----------------
 .form {
     display: flex;
-    flex-wrap: wrap;
-    align-items: flex-end;
-    gap: dt.$spacing-md;
+    flex-direction: column;
+    gap: dt.$spacing-xs;
 }
 
 .field {
     display: flex;
     flex-direction: column;
     gap: dt.$spacing-xs;
-    flex: 1 1 320px;
 }
 
 .label {
-    font-size: dt.$font-size-2xs;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    font-weight: 600;
-    color: var(--bs-secondary-color);
+    @include board.board-eyebrow;
 }
 
 .input,
@@ -61,12 +70,13 @@ $rail: 3px;
     }
 }
 
-// Prefix + input reading as one field: the prefix is the static
-// "https://www.speedrun.com/" part, the input is the game abbreviation.
+// Prefix + slug + primary action reading as one instrument: the static
+// "https://www.speedrun.com/" part, the abbreviation, the Fetch button.
 .urlGroup {
     display: flex;
     align-items: stretch;
     width: 100%;
+    max-width: 44rem;
 }
 
 .urlPrefix {
@@ -88,8 +98,40 @@ $rail: 3px;
 }
 
 .urlInput {
-    border-radius: 0 dt.$radius-md dt.$radius-md 0;
+    border-radius: 0;
     min-width: 0;
+    flex: 1;
+}
+
+.fetchBtn {
+    @include board.board-btn-primary;
+    border-radius: 0 dt.$radius-md dt.$radius-md 0;
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+
+// Narrow screens: the long prefix becomes a full-width cap above the
+// slug + action row.
+@media (max-width: 640px) {
+    .urlGroup {
+        flex-wrap: wrap;
+    }
+
+    .urlPrefix {
+        width: 100%;
+        border-right: 1px solid rgba(var(--bs-border-color-rgb), 0.6);
+        border-bottom: 0;
+        border-radius: dt.$radius-md dt.$radius-md 0 0;
+        padding-block: dt.$spacing-xs;
+    }
+
+    .urlInput {
+        border-radius: 0 0 0 dt.$radius-md;
+    }
+
+    .fetchBtn {
+        border-radius: 0 0 dt.$radius-md 0;
+    }
 }
 
 .select {
@@ -99,14 +141,12 @@ $rail: 3px;
     padding: dt.$spacing-xs dt.$spacing-sm;
 }
 
-// ---- Job status card ---------------------------------------
+// ---- Job status surface ------------------------------------
 .jobCard {
-    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
-    border-radius: dt.$radius-md;
-    padding: dt.$spacing-lg;
+    @include board.board-surface(dt.$spacing-lg dt.$spacing-xl);
     display: flex;
     flex-direction: column;
-    gap: dt.$spacing-md;
+    gap: dt.$spacing-lg;
 }
 
 .jobHead {
@@ -118,25 +158,31 @@ $rail: 3px;
 
 .jobTitle {
     font-weight: 600;
+    letter-spacing: -0.01em;
     color: var(--bs-emphasis-color);
 }
 
 .jobLink {
-    font-size: dt.$font-size-sm;
-    color: var(--bs-secondary-color);
-    word-break: break-all;
-}
-
-.statusBadge {
+    @include board.board-quiet-link;
     display: inline-flex;
     align-items: center;
     gap: dt.$spacing-xs;
-    padding: 0.15rem dt.$spacing-md;
-    border-radius: 999px;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+// Quiet timestamps, pushed to the surface's right edge.
+.jobTimes {
+    margin-left: auto;
     font-size: dt.$font-size-2xs;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
+    color: var(--bs-tertiary-color);
+    white-space: nowrap;
+}
+
+// Status as a board-pill; the sev variants recolor it.
+.statusBadge {
+    @include board.board-pill;
+    border-color: transparent;
 }
 
 .badgeQueued {
@@ -163,6 +209,10 @@ $rail: 3px;
     border-radius: 999px;
     animation: spin 0.7s linear infinite;
     flex-shrink: 0;
+
+    @media (prefers-reduced-motion: reduce) {
+        animation-duration: 1.6s;
+    }
 }
 
 @keyframes spin {
@@ -171,10 +221,15 @@ $rail: 3px;
     }
 }
 
+// ---- Stat bands --------------------------------------------
+// One row of eyebrow-labelled mono numerals; a hairline above sets the
+// band apart from the head. Stacked bands share the hairline rhythm.
 .counters {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: dt.$spacing-md;
+    grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+    gap: dt.$spacing-md dt.$spacing-lg;
+    padding-top: dt.$spacing-md;
+    border-top: 1px solid rgba(var(--bs-border-color-rgb), 0.35);
 }
 
 .counter {
@@ -191,10 +246,44 @@ $rail: 3px;
 }
 
 .counterLabel {
-    font-size: dt.$font-size-2xs;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--bs-secondary-color);
+    @include board.board-eyebrow;
+    letter-spacing: 0.06em;
+    color: var(--bs-tertiary-color);
+}
+
+// "What changed" is a different fact than "what was fetched": it gets a
+// tinted block with a green spine and its own eyebrow heading.
+.changedBand {
+    border-left: $rail solid var(--bs-primary);
+    border-radius: 0 dt.$radius-md dt.$radius-md 0;
+    background: rgba(var(--bs-primary-rgb), 0.05);
+    padding: dt.$spacing-md dt.$spacing-lg;
+    display: flex;
+    flex-direction: column;
+    gap: dt.$spacing-sm;
+
+    .counters {
+        border-top: 0;
+        padding-top: 0;
+    }
+}
+
+.bandLabel {
+    @include board.board-eyebrow;
+    margin: 0;
+}
+
+// Labelled stat group (plan preview): the eyebrow heading carries the
+// separation, so the band's own hairline is dropped.
+.band {
+    display: flex;
+    flex-direction: column;
+    gap: dt.$spacing-sm;
+
+    .counters {
+        border-top: 0;
+        padding-top: 0;
+    }
 }
 
 .muted {
@@ -223,6 +312,10 @@ $rail: 3px;
     border-radius: inherit;
     background: var(--bs-primary);
     transition: width 0.6s ease;
+
+    @media (prefers-reduced-motion: reduce) {
+        transition: none;
+    }
 }
 
 .progressPct {
@@ -246,12 +339,6 @@ $rail: 3px;
     color: var(--bs-secondary-color);
 }
 
-.calloutWarn {
-    border-left-color: dt.$accent-amber;
-    background: color-mix(in srgb, #{dt.$accent-amber} 10%, transparent);
-    color: color-mix(in srgb, #{dt.$accent-amber} 75%, var(--bs-body-color));
-}
-
 .calloutError {
     border-left-color: dt.$accent-red;
     background: color-mix(in srgb, #{dt.$accent-red} 10%, transparent);
@@ -259,51 +346,38 @@ $rail: 3px;
 }
 
 // ---- Review tables -----------------------------------------
+.tabBody {
+    margin-top: dt.$spacing-md;
+    display: flex;
+    flex-direction: column;
+    gap: dt.$spacing-sm;
+}
+
 .toolbar {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: dt.$spacing-md;
-    margin-bottom: dt.$spacing-md;
 }
 
 .tableWrap {
+    @include board.board-surface(0);
     overflow-x: auto;
 }
 
 .table {
-    width: 100%;
-    border-collapse: separate;
-    border-spacing: 0;
-    font-size: dt.$font-size-sm;
-    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
-    border-radius: dt.$radius-md;
-    overflow: hidden;
+    @include board.board-table;
 
-    th {
-        text-align: left;
-        font-size: dt.$font-size-2xs;
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
-        font-weight: 700;
-        color: var(--bs-secondary-color);
+    thead th {
         padding: dt.$spacing-sm dt.$spacing-md;
-        background: color-mix(
-            in srgb,
-            var(--bs-body-bg) 88%,
-            var(--bs-secondary-bg) 12%
-        );
-        border-bottom: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
-        white-space: nowrap;
     }
 
-    td {
+    tbody td {
         padding: dt.$spacing-sm dt.$spacing-md;
-        border-bottom: 1px solid rgba(var(--bs-border-color-rgb), 0.3);
         vertical-align: top;
     }
 
-    tr:last-child td {
+    tbody tr:last-child td {
         border-bottom: 0;
     }
 }
@@ -320,14 +394,10 @@ $rail: 3px;
 }
 
 .pill {
-    display: inline-block;
-    padding: 0.05rem dt.$spacing-sm;
-    border-radius: 999px;
-    font-size: dt.$font-size-2xs;
-    font-weight: 600;
-    background: rgba(var(--bs-secondary-rgb), 0.12);
-    color: var(--bs-secondary-color);
-    white-space: nowrap;
+    @include board.board-pill;
+    border-color: transparent;
+    text-transform: none;
+    letter-spacing: 0;
 }
 
 .pillPrimary {
@@ -340,6 +410,16 @@ $rail: 3px;
     color: color-mix(in srgb, #{dt.$accent-amber} 82%, var(--bs-body-color));
 }
 
+.pillRow {
+    display: flex;
+    flex-wrap: wrap;
+    gap: dt.$spacing-xs;
+}
+
+.gapLeft {
+    margin-left: dt.$spacing-xs;
+}
+
 .rules {
     max-width: 48ch;
     white-space: pre-wrap;
@@ -347,32 +427,66 @@ $rail: 3px;
     color: var(--bs-secondary-color);
 }
 
+.moreLink {
+    @include board.board-quiet-link;
+    font-size: dt.$font-size-xs;
+    text-decoration: underline;
+    vertical-align: baseline;
+}
+
 .pager {
     display: flex;
     align-items: center;
     gap: dt.$spacing-md;
-    margin-top: dt.$spacing-md;
     font-size: dt.$font-size-sm;
     color: var(--bs-secondary-color);
+}
+
+.pagerBtn {
+    @include board.control-pill;
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
 }
 
 .empty {
-    padding: dt.$spacing-xl;
-    text-align: center;
-    color: var(--bs-secondary-color);
-    font-size: dt.$font-size-sm;
-    border: 1px dashed rgba(var(--bs-border-color-rgb), 0.6);
-    border-radius: dt.$radius-md;
+    @include board.board-empty;
 }
 
-// ---- Commit panel --------------------------------------------
+// ---- Commit zone -------------------------------------------
+// The one place on this pane that writes to the live board: its own
+// surface, amber caution spine, a named header. Everything above it is
+// review; everything inside it is consequence.
 .commitCard {
-    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
-    border-radius: dt.$radius-md;
-    padding: dt.$spacing-lg;
+    @include board.board-surface(dt.$spacing-lg dt.$spacing-xl);
+    border-left: $rail solid dt.$accent-amber;
     display: flex;
     flex-direction: column;
-    gap: dt.$spacing-md;
+    gap: dt.$spacing-lg;
+}
+
+.commitHead {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding-bottom: dt.$spacing-sm;
+    border-bottom: 1px solid rgba(var(--bs-border-color-rgb), 0.35);
+}
+
+.commitEyebrow {
+    @include board.board-eyebrow;
+    color: color-mix(in srgb, #{dt.$accent-amber} 80%, var(--bs-body-color));
+}
+
+.commitTitle {
+    font-size: dt.$font-size-md;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    margin: 0;
+}
+
+.commitLede {
+    font-size: dt.$font-size-sm;
+    color: var(--bs-secondary-color);
+    margin: 0;
 }
 
 .actionRow {
@@ -382,33 +496,19 @@ $rail: 3px;
     gap: dt.$spacing-md;
 }
 
-// Outline counterpart to kit's saveBtn — "Undo config", "Undo runs",
+// Outline counterpart to the primary tier — "Undo config", "Undo runs",
 // "Reverse SRC-only leaderboard" read as reversals, not the primary path.
 .secondaryBtn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.35rem;
+    @include board.control-pill;
     border: 1px solid rgba(var(--bs-border-color-rgb), 0.6);
     border-radius: dt.$radius-md;
-    background: transparent;
-    color: var(--bs-body-color);
-    font-size: dt.$font-size-sm;
     font-weight: 600;
     padding: dt.$spacing-sm dt.$spacing-lg;
-    cursor: pointer;
-    transition:
-        border-color dt.$transition-fast,
-        color dt.$transition-fast;
 
     &:hover:not(:disabled) {
         border-color: var(--bs-primary);
         color: var(--bs-primary);
-    }
-
-    &:disabled {
-        opacity: 0.5;
-        cursor: default;
+        background: transparent;
     }
 }
 
@@ -428,11 +528,11 @@ $rail: 3px;
 .blockedHint {
     color: var(--bs-secondary-color);
     font-size: dt.$font-size-xs;
+    margin: 0;
 }
 
-// "Import options" — the moderator commit-flag toggles, shown while the plan
-// is being reviewed (before Apply config), the same lifecycle slot as the
-// SRC-only checkbox.
+// "Import options" — the moderator commit-flag toggles, shown while the
+// plan is being reviewed (before Apply config).
 .optionsPanel {
     border: 1px solid rgba(var(--bs-border-color-rgb), 0.4);
     border-radius: dt.$radius-md;
@@ -443,8 +543,7 @@ $rail: 3px;
 }
 
 .optionsTitle {
-    font-size: dt.$font-size-sm;
-    font-weight: 600;
+    @include board.board-eyebrow;
     margin: 0;
 }
 
@@ -469,6 +568,17 @@ $rail: 3px;
     border-radius: dt.$radius-md;
     padding: 0.15rem 0.4rem;
     font-size: dt.$font-size-xs;
+    transition: border-color dt.$transition-fast;
+
+    &:hover {
+        border-color: rgba(var(--bs-primary-rgb), 0.5);
+    }
+
+    &:focus-visible {
+        outline: 0;
+        border-color: var(--bs-primary);
+        @include focus-ring;
+    }
 }
 
 .conflictList {
@@ -500,9 +610,15 @@ $rail: 3px;
     font-size: dt.$font-size-xs;
     font-weight: 600;
     cursor: pointer;
+    transition: background-color dt.$transition-fast;
 
     &:hover:not(:disabled) {
         background: color-mix(in srgb, currentcolor 12%, transparent);
+    }
+
+    &:focus-visible {
+        outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
+        outline-offset: 1px;
     }
 
     &:disabled {

--- a/app/(new-layout)/games-v2/[game]/setup/game-details-form.tsx
+++ b/app/(new-layout)/games-v2/[game]/setup/game-details-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState, useTransition } from 'react';
+import { Plus } from 'react-bootstrap-icons';
 import type {
     GameIdentifiers,
     GameLink,
@@ -329,7 +330,7 @@ function GameDetailsFormInner({
                         }}
                     />
                 )}
-                <div>
+                <div className="d-flex flex-column align-items-start gap-1">
                     <input
                         ref={fileInputRef}
                         id="cover-upload"
@@ -343,7 +344,7 @@ function GameDetailsFormInner({
                     />
                     <button
                         type="button"
-                        className="btn btn-sm btn-outline-primary d-block"
+                        className={styles.secondaryAction}
                         disabled={isUploading || isSaving}
                         onClick={() => fileInputRef.current?.click()}
                     >
@@ -356,7 +357,7 @@ function GameDetailsFormInner({
                     {coverUrl.trim() && (
                         <button
                             type="button"
-                            className="btn btn-sm btn-link px-0 d-block"
+                            className={styles.skipAction}
                             disabled={isUploading || isSaving}
                             onClick={() => setCoverUrl('')}
                         >
@@ -512,7 +513,7 @@ function GameDetailsFormInner({
                     <button
                         key={preset.label}
                         type="button"
-                        className="btn btn-sm btn-outline-secondary"
+                        className={styles.secondaryAction}
                         disabled={
                             links.length >= 10 ||
                             links.some((l) => l.label === preset.label)
@@ -524,7 +525,8 @@ function GameDetailsFormInner({
                             ])
                         }
                     >
-                        + {preset.label}
+                        <Plus size={16} aria-hidden />
+                        {preset.label}
                     </button>
                 ))}
             </div>
@@ -551,7 +553,7 @@ function GameDetailsFormInner({
                     />
                     <button
                         type="button"
-                        className="btn btn-sm btn-outline-danger"
+                        className={styles.dangerAction}
                         onClick={() => removeLink(index)}
                     >
                         Remove
@@ -560,10 +562,11 @@ function GameDetailsFormInner({
             ))}
             <button
                 type="button"
-                className="btn btn-sm btn-outline-secondary"
+                className={styles.secondaryAction}
                 disabled={links.length >= 10}
                 onClick={addLink}
             >
+                <Plus size={16} aria-hidden />
                 Add link
             </button>
         </>

--- a/app/(new-layout)/games-v2/[game]/setup/igdb-source-card.tsx
+++ b/app/(new-layout)/games-v2/[game]/setup/igdb-source-card.tsx
@@ -116,7 +116,7 @@ export function IgdbSourceCard({
                 {canRematch ? (
                     <button
                         type="button"
-                        className="btn btn-sm btn-outline-secondary"
+                        className={styles.secondaryAction}
                         disabled={disabled || isBusy}
                         onClick={() => setSearchOpen((o) => !o)}
                     >
@@ -135,7 +135,7 @@ export function IgdbSourceCard({
                     (resetRows.length > 0 ? (
                         <button
                             type="button"
-                            className="btn btn-sm btn-outline-secondary"
+                            className={styles.secondaryAction}
                             disabled={disabled || isBusy}
                             onClick={() => setResetOpen(true)}
                         >
@@ -164,7 +164,7 @@ export function IgdbSourceCard({
                         />
                         <button
                             type="button"
-                            className="btn btn-sm btn-outline-secondary"
+                            className={styles.secondaryAction}
                             disabled={isBusy || !query.trim()}
                             onClick={search}
                         >
@@ -204,7 +204,7 @@ export function IgdbSourceCard({
                                     </span>
                                     <button
                                         type="button"
-                                        className="btn btn-sm btn-outline-primary ms-auto"
+                                        className={`${styles.secondaryAction} ms-auto`}
                                         disabled={isBusy}
                                         onClick={() => setPendingApply(r)}
                                     >
@@ -217,7 +217,9 @@ export function IgdbSourceCard({
                 </div>
             )}
             {error && (
-                <div className="alert alert-danger mt-2 mb-0 py-2">{error}</div>
+                <div role="alert" className={`${styles.errorNote} mt-2 mb-0`}>
+                    {error}
+                </div>
             )}
             <ConfirmDialog
                 open={pendingApply != null}

--- a/app/(new-layout)/games-v2/[game]/setup/setup.module.scss
+++ b/app/(new-layout)/games-v2/[game]/setup/setup.module.scss
@@ -714,6 +714,17 @@ $rail-collapse: 900px;
     }
 }
 
+// Quiet destructive row action (remove a link row): tertiary tier that turns
+// $accent-red on hover — never Bootstrap's danger (one-red rule).
+.dangerAction {
+    @include board.board-quiet-link;
+    font-size: dt.$font-size-sm;
+
+    &:hover {
+        color: dt.$accent-red;
+    }
+}
+
 // ---- Step section anatomy -----------------------------------
 .section {
     @include board.board-surface(dt.$spacing-xl);

--- a/app/(new-layout)/games-v2/[game]/setup/steps/variables/add-variable-form.tsx
+++ b/app/(new-layout)/games-v2/[game]/setup/steps/variables/add-variable-form.tsx
@@ -161,14 +161,14 @@ export function AddVariableForm({
                 />
             </label>
             <p className={styles.addNote}>
-                What runners set in their splits — runs are matched on this.
+                What runners set in their splits: runs are matched on this.
                 Defaults to the display name; change it only if the two differ.
             </p>
 
             <label className={styles.addField}>
                 <span className={styles.addLabel}>
-                    {SECTION[role].options}, one per line — add other accepted
-                    spellings after a comma
+                    {SECTION[role].options}, one per line (other accepted
+                    spellings after a comma)
                 </span>
                 <textarea
                     className={styles.addTextarea}
@@ -245,7 +245,7 @@ export function AddVariableForm({
             {collision && <p className={styles.addError}>{collision}</p>}
             {offList && (
                 <p className={styles.addWarning}>
-                    Few runners set &ldquo;{name.trim()}&rdquo; — it isn&rsquo;t
+                    Few runners set &ldquo;{name.trim()}&rdquo;: it isn&rsquo;t
                     among the suggested variables. You can still add it.
                 </p>
             )}
@@ -257,7 +257,7 @@ export function AddVariableForm({
                               selectedIds.length === 1
                                   ? 'category is'
                                   : 'categories are'
-                          } multiplied by ${options.length} — every one splits into ${options.length} subcategories with their own records.`
+                          } multiplied by ${options.length}: every one splits into ${options.length} subcategories with their own records.`
                         : 'A subcategory group needs at least two options to split anything.'
                     : `Added to ${selectedIds.length} ${
                           selectedIds.length === 1 ? 'category' : 'categories'

--- a/app/(new-layout)/games-v2/[game]/setup/steps/variables/option-editor.tsx
+++ b/app/(new-layout)/games-v2/[game]/setup/steps/variables/option-editor.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { ArrowLeft, ArrowRight } from 'react-bootstrap-icons';
 import type { BoardBucket } from '~src/lib/setup/variable-view';
 import { SECTION, type VariableRoleId } from '~src/lib/variables/language';
 import styles from './variables-grid.module.scss';
@@ -127,7 +128,7 @@ export function OptionEditor({
                             aria-label={`Move ${bucket.label} left`}
                             onClick={() => move(-1)}
                         >
-                            ←
+                            <ArrowLeft size={16} aria-hidden />
                         </button>
                         <button
                             type="button"
@@ -136,7 +137,7 @@ export function OptionEditor({
                             aria-label={`Move ${bucket.label} right`}
                             onClick={() => move(1)}
                         >
-                            →
+                            <ArrowRight size={16} aria-hidden />
                         </button>
                         <button
                             type="button"

--- a/app/(new-layout)/games-v2/[game]/setup/steps/variables/variable-palette.tsx
+++ b/app/(new-layout)/games-v2/[game]/setup/steps/variables/variable-palette.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { CaretDownFill, Pencil, Plus } from 'react-bootstrap-icons';
 import type { BoardBucket, VariableGroup } from '~src/lib/setup/variable-view';
 import { driftSides } from '~src/lib/setup/variable-view';
 import {
@@ -236,7 +237,9 @@ export function VariablePalette({
                                 e.stopPropagation();
                                 setOpen((v) => !v);
                             }}
-                        />
+                        >
+                            <CaretDownFill size={12} aria-hidden />
+                        </button>
                     </>
                 )}
             </div>
@@ -438,6 +441,13 @@ export function VariablePalette({
                                                             }
                                                         </span>
                                                     )}
+                                                    <Pencil
+                                                        size={12}
+                                                        className={
+                                                            styles.optionEditIcon
+                                                        }
+                                                        aria-hidden
+                                                    />
                                                 </button>
                                             </th>
                                         ))}
@@ -459,7 +469,8 @@ export function VariablePalette({
                                                     setAddingOption((v) => !v);
                                                 }}
                                             >
-                                                + Option
+                                                <Plus size={14} aria-hidden />
+                                                Option
                                             </button>
                                         </th>
 

--- a/app/(new-layout)/games-v2/[game]/setup/steps/variables/variable-suggestions.module.scss
+++ b/app/(new-layout)/games-v2/[game]/setup/steps/variables/variable-suggestions.module.scss
@@ -80,14 +80,18 @@
 }
 
 // Reserved status green — the bars stay monochrome so this reads as state.
+// The one brand green (system.md's one-green rule), not $accent-green.
 .pillAdded {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
     flex: none;
     font-size: dt.$font-size-xs;
     font-weight: 600;
     padding: 0.1rem 0.5rem;
     border-radius: 999px;
-    color: dt.$accent-green;
-    background: rgba(76, 175, 80, 0.12);
+    color: var(--bs-primary);
+    background: rgba(var(--bs-primary-rgb), 0.1);
     white-space: nowrap;
 }
 
@@ -216,7 +220,7 @@
 
 .coveredNote {
     font-size: dt.$font-size-sm;
-    color: dt.$accent-green;
+    color: var(--bs-primary);
 }
 
 .gapNote {
@@ -234,32 +238,19 @@
     margin-top: dt.$spacing-xs;
 }
 
+// The action hierarchy, at card scale: primary = board-btn-primary,
+// secondary = control-pill. Padding slimmed so a footer of two actions
+// stays quieter than the pane's own primary action.
 .addPrimary {
-    font-size: dt.$font-size-sm;
-    font-weight: 600;
+    @include board.board-btn-primary;
     padding: 0.3rem 0.85rem;
-    border-radius: dt.$radius-sm;
-    border: 1px solid var(--bs-primary);
-    background: var(--bs-primary);
-    color: #fff;
-    cursor: pointer;
 
-    &:hover {
-        filter: brightness(1.08);
+    @media (pointer: coarse) {
+        min-height: 44px;
     }
 }
 
 .addSecondary {
-    font-size: dt.$font-size-sm;
-    font-weight: 600;
+    @include board.control-pill;
     padding: 0.3rem 0.85rem;
-    border-radius: dt.$radius-sm;
-    border: 1px solid rgba(var(--bs-border-color-rgb), 0.7);
-    background: transparent;
-    color: var(--bs-body-color);
-    cursor: pointer;
-
-    &:hover {
-        background: rgba(var(--bs-border-color-rgb), 0.2);
-    }
 }

--- a/app/(new-layout)/games-v2/[game]/setup/steps/variables/variable-suggestions.tsx
+++ b/app/(new-layout)/games-v2/[game]/setup/steps/variables/variable-suggestions.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { Check, GripVertical } from 'react-bootstrap-icons';
 import type { CategoryVariableSuggestion } from '~src/lib/leaderboard-variables';
 import { normalizeVariableName } from '~src/lib/variables/keys';
 import type { VariableRoleId } from '~src/lib/variables/language';
@@ -224,7 +225,10 @@ function SuggestionCard({
                     prettier title here only adds a second name to reconcile. */}
                 <span className={styles.name}>{s.variable}</span>
                 {state !== 'new' && (
-                    <span className={styles.pillAdded}>✓ {addedRoleText}</span>
+                    <span className={styles.pillAdded}>
+                        <Check size={14} aria-hidden />
+                        {addedRoleText}
+                    </span>
                 )}
             </div>
 
@@ -259,7 +263,7 @@ function SuggestionCard({
                             title={b.aliases.join(', ')}
                         >
                             <span className={styles.dragHandle} aria-hidden>
-                                ⠿
+                                <GripVertical size={12} />
                             </span>
                             {b.label === '' ? '(blank)' : b.label}
                             {b.aliases.length > 1 && (

--- a/app/(new-layout)/games-v2/[game]/setup/steps/variables/variables-grid.module.scss
+++ b/app/(new-layout)/games-v2/[game]/setup/steps/variables/variables-grid.module.scss
@@ -73,6 +73,10 @@
     @include board.board-empty-title;
 }
 
+.emptyIcon {
+    @include board.board-empty-icon;
+}
+
 .emptyNote {
     font-size: dt.$font-size-sm;
     color: var(--bs-secondary-color);
@@ -179,16 +183,20 @@
     cursor: pointer;
 
     // A filled disclosure triangle rather than a chevron: it reads as "this
-    // opens" rather than as a direction, which is what it means.
-    &::after {
-        content: '▾';
-        font-size: dt.$font-size-sm;
-        line-height: 1;
+    // opens" rather than as a direction, which is what it means. Drawn as a
+    // react-bootstrap-icons CaretDownFill in the markup, not a text glyph.
+    svg {
         transition: transform dt.$transition-fast;
     }
 
-    &[aria-expanded='false']::after {
+    &[aria-expanded='false'] svg {
         transform: rotate(-90deg);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        svg {
+            transition: none;
+        }
     }
 
     &:hover {
@@ -226,13 +234,13 @@
     letter-spacing: -0.01em;
     color: var(--bs-emphasis-color);
     background: var(--bs-body-bg);
-    border: 1px solid rgba(var(--bs-border-color-rgb), 0.6);
-    border-radius: dt.$radius-sm;
+    border: 1px solid;
     padding: 0 dt.$spacing-xs;
+    @include board.board-input-rules;
 
+    &:focus,
     &:focus-visible {
-        outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
-        outline-offset: 1px;
+        outline: 0;
     }
 }
 
@@ -254,8 +262,8 @@
     cursor: pointer;
 
     &:hover:not(:disabled) {
-        border-color: rgba(var(--bs-danger-rgb), 0.6);
-        color: var(--bs-danger);
+        border-color: rgba(dt.$accent-red, 0.6);
+        color: dt.$accent-red;
     }
 }
 
@@ -272,6 +280,8 @@
     padding: dt.$spacing-sm dt.$spacing-lg;
     border-top: 1px solid rgba(dt.$accent-amber, 0.35);
     border-bottom: 1px solid rgba(dt.$accent-amber, 0.35);
+    // The severity spine: this strip is a medium-severity attention item.
+    border-left: 3px solid dt.$accent-amber;
     background: rgba(dt.$accent-amber, 0.08);
 }
 
@@ -421,8 +431,8 @@
     }
 
     &:hover:not(:disabled) {
-        color: var(--bs-danger);
-        border-color: rgba(var(--bs-danger-rgb), 0.4);
+        color: dt.$accent-red;
+        border-color: rgba(dt.$accent-red, 0.4);
     }
 
     &:disabled {
@@ -443,6 +453,9 @@
 // corner, the easiest thing on the grid to miss. Given the primary accent and
 // a tick more weight so it reads as an action, not a decoration.
 .addOption {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
     font: inherit;
     font-size: dt.$font-size-2xs;
     font-weight: 600;
@@ -507,8 +520,8 @@
     font-size: dt.$font-size-2xs;
 
     &:hover:not(:disabled) {
-        border-color: rgba(var(--bs-danger-rgb), 0.6);
-        color: var(--bs-danger);
+        border-color: rgba(dt.$accent-red, 0.6);
+        color: dt.$accent-red;
     }
 }
 
@@ -519,9 +532,11 @@
     gap: dt.$spacing-sm;
     flex-wrap: wrap;
     padding: dt.$spacing-sm dt.$spacing-lg;
-    border-top: 1px solid rgba(var(--bs-danger-rgb), 0.35);
-    border-bottom: 1px solid rgba(var(--bs-danger-rgb), 0.35);
-    background: rgba(var(--bs-danger-rgb), 0.07);
+    border-top: 1px solid rgba(dt.$accent-red, 0.35);
+    border-bottom: 1px solid rgba(dt.$accent-red, 0.35);
+    // High severity: the one action here that destroys leaderboards.
+    border-left: 3px solid dt.$accent-red;
+    background: rgba(dt.$accent-red, 0.07);
 }
 
 .deleteWarning {
@@ -533,9 +548,9 @@
 
 .deleteConfirm {
     @include board.board-chip;
-    border-color: rgba(var(--bs-danger-rgb), 0.7);
-    background: rgba(var(--bs-danger-rgb), 0.12);
-    color: var(--bs-danger);
+    border-color: rgba(dt.$accent-red, 0.7);
+    background: rgba(dt.$accent-red, 0.12);
+    color: dt.$accent-red;
     font-weight: 600;
 }
 
@@ -733,22 +748,14 @@
     text-underline-offset: 3px;
     text-decoration-color: rgba(var(--bs-border-color-rgb), 0.8);
 
-    &::after {
-        content: '✎';
-        font-size: dt.$font-size-2xs;
-        color: var(--bs-tertiary-color);
-        opacity: 0;
-        transition: opacity dt.$transition-fast;
-    }
-
     &:hover {
         color: var(--bs-emphasis-color);
         text-decoration-color: currentcolor;
     }
 
-    &:hover::after,
-    &:focus-visible::after,
-    &[aria-expanded='true']::after {
+    &:hover .optionEditIcon,
+    &:focus-visible .optionEditIcon,
+    &[aria-expanded='true'] .optionEditIcon {
         opacity: 1;
     }
 
@@ -756,6 +763,15 @@
         outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
         outline-offset: 2px;
     }
+}
+
+// The hover-revealed edit mark on an option header. An icon in the markup
+// (react-bootstrap-icons Pencil), not a ::after glyph.
+.optionEditIcon {
+    flex: none;
+    color: var(--bs-tertiary-color);
+    opacity: 0;
+    transition: opacity dt.$transition-fast;
 }
 
 // How many other spellings resolve to this option — the only hint that a
@@ -793,8 +809,8 @@
 
 .optionRemove {
     @include board.board-chip;
-    border-color: rgba(var(--bs-danger-rgb), 0.5);
-    color: var(--bs-danger);
+    border-color: rgba(dt.$accent-red, 0.5);
+    color: dt.$accent-red;
 }
 
 .optionNote {
@@ -829,10 +845,16 @@
     font: inherit;
     font-size: dt.$font-size-2xs;
     padding: 0.1rem dt.$spacing-xs;
-    border-radius: dt.$radius-sm;
-    border: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
+    border: 1px solid;
     background: transparent;
     color: var(--bs-body-color);
+    @include board.board-input-rules;
+    border-radius: dt.$radius-sm;
+
+    &:focus,
+    &:focus-visible {
+        outline: 0;
+    }
 }
 
 .defaultNone {
@@ -847,7 +869,10 @@
 // creates a whole object with leaderboards behind it, and the control that
 // does it should stand where the object will stand.
 .addAction {
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
     width: 100%;
     padding: dt.$spacing-lg;
     font: inherit;
@@ -899,14 +924,14 @@
     font: inherit;
     font-size: dt.$font-size-sm;
     padding: dt.$spacing-xs dt.$spacing-sm;
-    border-radius: dt.$radius-sm;
-    border: 1px solid rgba(var(--bs-border-color-rgb), 0.6);
+    border: 1px solid;
     background: var(--bs-body-bg);
     color: var(--bs-body-color);
+    @include board.board-input-rules;
 
+    &:focus,
     &:focus-visible {
-        outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
-        outline-offset: 1px;
+        outline: 0;
     }
 }
 
@@ -917,13 +942,13 @@
 .addError {
     margin: 0;
     font-size: dt.$font-size-sm;
-    color: var(--bs-danger);
+    color: dt.$accent-red;
 }
 
 .addWarning {
     margin: 0;
     font-size: dt.$font-size-sm;
-    color: var(--bs-warning-text-emphasis, #997404);
+    color: dt.$accent-amber;
 }
 
 .addCategories {
@@ -958,7 +983,7 @@
 .dialogBackdrop {
     position: fixed;
     inset: 0;
-    z-index: 1080;
+    z-index: dt.$z-dialog;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -975,8 +1000,9 @@
     border-radius: dt.$radius-lg;
     background: var(--board-surface-bg, var(--bs-body-bg));
     border: 1px solid rgba(var(--bs-border-color-rgb), 0.6);
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+    box-shadow: dt.$shadow-lg;
     overflow: hidden;
+    @include board.board-overlay-enter;
 }
 
 .dialogHeader {
@@ -1055,8 +1081,7 @@ details[open] > .noteSummary::before {
     font: inherit;
     font-size: dt.$font-size-sm;
     padding: dt.$spacing-xs dt.$spacing-sm;
-    border-radius: dt.$radius-sm;
-    border: 1px solid rgba(var(--bs-border-color-rgb), 0.6);
+    border: 1px solid;
     background: var(--bs-body-bg);
     color: var(--bs-body-color);
     display: block;
@@ -1064,10 +1089,11 @@ details[open] > .noteSummary::before {
     max-width: 34rem;
     margin-top: dt.$spacing-sm;
     resize: vertical;
+    @include board.board-input-rules;
 
+    &:focus,
     &:focus-visible {
-        outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
-        outline-offset: 1px;
+        outline: 0;
     }
 }
 

--- a/app/(new-layout)/games-v2/[game]/setup/steps/variables/variables-grid.test.tsx
+++ b/app/(new-layout)/games-v2/[game]/setup/steps/variables/variables-grid.test.tsx
@@ -391,7 +391,7 @@ describe('VariablesGrid', () => {
 
     it('adds an option, in the column where it will appear', () => {
         renderGrid();
-        fireEvent.click(screen.getByRole('button', { name: '+ Option' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Option' }));
         fireEvent.change(screen.getByLabelText('Name'), {
             target: { value: 'Wii' },
         });
@@ -411,7 +411,7 @@ describe('VariablesGrid', () => {
 
     it('refuses an option that already exists rather than silently merging it', () => {
         renderGrid();
-        fireEvent.click(screen.getByRole('button', { name: '+ Option' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Option' }));
         fireEvent.change(screen.getByLabelText('Name'), {
             target: { value: 'emulator' },
         });
@@ -426,7 +426,7 @@ describe('VariablesGrid', () => {
     it('asks where unmatched runs go when creating, instead of taking the first', () => {
         renderGrid();
         fireEvent.click(
-            screen.getByRole('button', { name: '+ Add a subcategory group' }),
+            screen.getByRole('button', { name: 'Add a subcategory group' }),
         );
         fireEvent.change(screen.getByLabelText('Subcategory display name'), {
             target: { value: 'Region' },
@@ -468,7 +468,7 @@ describe('VariablesGrid', () => {
     it('lets the display name and the LiveSplit variable be set apart on create', () => {
         renderGrid();
         fireEvent.click(
-            screen.getByRole('button', { name: '+ Add a subcategory group' }),
+            screen.getByRole('button', { name: 'Add a subcategory group' }),
         );
         fireEvent.change(screen.getByLabelText('Subcategory display name'), {
             target: { value: 'Solo or Co-op?' },

--- a/app/(new-layout)/games-v2/[game]/setup/steps/variables/variables-grid.tsx
+++ b/app/(new-layout)/games-v2/[game]/setup/steps/variables/variables-grid.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState, useTransition } from 'react';
+import { Collection, Diagram3, Funnel, Plus } from 'react-bootstrap-icons';
 import { toast } from 'react-toastify';
 import { compareByBoardOrder } from '~src/lib/console/category-order';
 import type {
@@ -893,11 +894,15 @@ export function VariablesGrid({
     if (mains.length === 0) {
         return (
             <div className={styles.empty}>
+                <Collection
+                    size={24}
+                    className={styles.emptyIcon}
+                    aria-hidden
+                />
                 <p className={styles.emptyTitle}>No featured categories yet</p>
                 <p className={styles.emptyNote}>
-                    Feature at least one category first — subcategories and
-                    filters are configured per featured category, so there is
-                    nothing to structure yet.
+                    Feature at least one category first. Subcategories and
+                    filters are configured per featured category.
                 </p>
             </div>
         );
@@ -1235,13 +1240,26 @@ function VariableSection({
                         </span>
                     ))}
                     <span className={styles.builtInsNote}>
-                        built in — nothing to configure
+                        built in (nothing to configure)
                     </span>
                 </div>
             )}
 
             {groups.length === 0 ? (
                 <div className={styles.empty}>
+                    {role === 'subcategory' ? (
+                        <Diagram3
+                            size={24}
+                            className={styles.emptyIcon}
+                            aria-hidden
+                        />
+                    ) : (
+                        <Funnel
+                            size={24}
+                            className={styles.emptyIcon}
+                            aria-hidden
+                        />
+                    )}
                     <p className={styles.emptyTitle}>
                         {role === 'subcategory'
                             ? 'No subcategories'
@@ -1249,7 +1267,7 @@ function VariableSection({
                     </p>
                     <p className={styles.emptyNote}>
                         {role === 'subcategory'
-                            ? 'Every featured category is a single leaderboard. Add a subcategory group when a category is really several leaderboards — Platform, Region, Glitches — each with its own record.'
+                            ? 'Every featured category is a single leaderboard. Add a subcategory group when a category is really several leaderboards (Platform, Region, Glitches), each with its own record.'
                             : 'Add a filter when runners should be able to narrow a leaderboard by something the run carries, without it becoming a subcategory.'}
                     </p>
                 </div>
@@ -1334,7 +1352,8 @@ function VariableSection({
                     disabled={busy}
                     onClick={() => setAdding(true)}
                 >
-                    + {copy.add}
+                    <Plus size={16} aria-hidden />
+                    {copy.add}
                 </button>
             )}
         </section>

--- a/src/components/console-chrome/console-chrome.tsx
+++ b/src/components/console-chrome/console-chrome.tsx
@@ -36,6 +36,10 @@ interface Props {
      * sidebar becomes a floating panel on the page canvas. Manage/admin omit
      * it and keep the contained framed console. */
     plain?: boolean;
+    /** The manage console's open layout: no frame box, no header row — the
+     * game's identity (cover, name, exits) lives in a sidebar masthead and
+     * the content sits directly on the page canvas. Settings omits it. */
+    cockpit?: boolean;
     children: ReactNode;
 }
 
@@ -56,6 +60,7 @@ export function ConsoleChrome({
     footerItems,
     navAriaLabel,
     plain = false,
+    cockpit = false,
     children,
 }: Props) {
     const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -92,6 +97,93 @@ export function ConsoleChrome({
         setSidebarOpen(false);
         onNavigate(id);
     };
+
+    if (cockpit) {
+        const sidebarBody = (
+            <>
+                <div className={styles.mast}>
+                    {header.image && (
+                        <img
+                            className={styles.mastCover}
+                            src={header.image}
+                            alt=""
+                            width={48}
+                            height={64}
+                            loading="eager"
+                        />
+                    )}
+                    <div className={styles.mastText}>
+                        <div className={styles.eyebrow}>
+                            {header.eyebrow ?? 'Admin console'}
+                        </div>
+                        <h1 className={styles.mastTitle}>
+                            <Link
+                                href={header.titleHref}
+                                className={styles.titleLink}
+                            >
+                                {header.title}
+                            </Link>
+                        </h1>
+                    </div>
+                </div>
+                <ConsoleSidebar
+                    groups={groups}
+                    icons={icons}
+                    activeItem={activeItem}
+                    onSelect={handleSelect}
+                    badges={badges}
+                    hrefFor={hrefFor}
+                    onLinkNavigate={closeSidebar}
+                    footerItems={footerItems}
+                    ariaLabel={navAriaLabel}
+                />
+                {header.actions && (
+                    <div className={styles.mastExits}>{header.actions}</div>
+                )}
+            </>
+        );
+        return (
+            <div className={styles.cockpit}>
+                <div className={styles.topbar}>
+                    <button
+                        type="button"
+                        className={clsx(
+                            styles.menuToggle,
+                            'btn btn-sm btn-outline-secondary',
+                        )}
+                        aria-label="Toggle navigation"
+                        aria-expanded={sidebarOpen}
+                        onClick={() => setSidebarOpen((v) => !v)}
+                    >
+                        <List size={18} aria-hidden="true" />
+                    </button>
+                    <span className={styles.topbarTitle}>{header.title}</span>
+                </div>
+                <div className={styles.cockpitBody}>
+                    {sidebarOpen && (
+                        <button
+                            type="button"
+                            className={styles.scrim}
+                            aria-label="Close navigation"
+                            onClick={closeSidebar}
+                        />
+                    )}
+                    <aside
+                        ref={sidebarRef}
+                        className={clsx(
+                            styles.spine,
+                            !sidebarOpen && styles.sidebarHidden,
+                        )}
+                    >
+                        <div className={styles.spineInner}>{sidebarBody}</div>
+                    </aside>
+                    <section className={styles.cockpitContent}>
+                        {children}
+                    </section>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className={clsx(styles.shell, plain && styles.plain)}>

--- a/src/components/console-chrome/console.module.scss
+++ b/src/components/console-chrome/console.module.scss
@@ -8,7 +8,144 @@
 // ============================================================
 
 $sidebar-width: 16rem;
+$spine-width: 15.5rem; // cockpit sidebar column
 $rail: 3px; // severity spine / active accent width
+
+// ---- Cockpit layout (manage console) ------------------------
+// No frame box, no header row. The sidebar is the console's spine:
+// game identity on top, nav in the middle, exits at the bottom —
+// content sits directly on the page canvas, one hairline away.
+// Confidence comes from space, not borders.
+.cockpit {
+    // nothing on the wrapper itself; the page container provides margins
+}
+
+.cockpitBody {
+    display: grid;
+    grid-template-columns: $spine-width minmax(0, 1fr);
+    align-items: stretch;
+    min-height: 70vh;
+}
+
+.spine {
+    border-right: 1px solid rgba(var(--bs-border-color-rgb), 0.4);
+    padding-right: dt.$spacing-xl;
+}
+
+.spineInner {
+    position: sticky;
+    top: dt.$spacing-lg;
+    display: flex;
+    flex-direction: column;
+    gap: dt.$spacing-xl;
+    max-height: calc(100dvh - #{dt.$spacing-3xl});
+    overflow-y: auto;
+    padding-bottom: dt.$spacing-lg;
+    scrollbar-width: thin;
+}
+
+.mast {
+    display: flex;
+    align-items: center;
+    gap: dt.$spacing-md;
+    padding-bottom: dt.$spacing-lg;
+    border-bottom: 1px solid rgba(var(--bs-border-color-rgb), 0.35);
+}
+
+.mastCover {
+    width: 48px;
+    height: 64px; // 3:4
+    border-radius: dt.$radius-md;
+    object-fit: cover;
+    box-shadow: dt.$shadow-sm;
+    flex-shrink: 0;
+}
+
+.mastText {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.mastTitle {
+    font-size: dt.$font-size-md;
+    font-weight: 700;
+    letter-spacing: -0.015em;
+    line-height: 1.2;
+    margin: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+// Exit doors (back to leaderboard, all your games) — quiet links,
+// visually apart from the nav below a hairline.
+.mastExits {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: dt.$spacing-sm;
+    padding-top: dt.$spacing-lg;
+    border-top: 1px solid rgba(var(--bs-border-color-rgb), 0.35);
+}
+
+.topbar {
+    display: none;
+}
+
+.cockpitContent {
+    min-width: 0;
+    padding: dt.$spacing-xs 0 dt.$spacing-3xl dt.$spacing-3xl;
+}
+
+@media (max-width: 768px) {
+    .cockpitBody {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .topbar {
+        display: flex;
+        align-items: center;
+        gap: dt.$spacing-md;
+        padding-bottom: dt.$spacing-md;
+        margin-bottom: dt.$spacing-md;
+        border-bottom: 1px solid rgba(var(--bs-border-color-rgb), 0.4);
+    }
+
+    .topbarTitle {
+        font-weight: 700;
+        letter-spacing: -0.01em;
+    }
+
+    // Same overlay drawer as the framed console's .sidebar below.
+    .spine {
+        position: fixed;
+        inset-block: 0;
+        left: 0;
+        width: min(20rem, 85vw);
+        z-index: dt.$z-drawer;
+        background: var(--bs-body-bg);
+        border-right: 1px solid rgba(var(--bs-border-color-rgb), 0.4);
+        padding: dt.$spacing-lg;
+        overflow-y: auto;
+        @include board.board-overlay-enter(slide-left);
+
+        &.sidebarHidden {
+            display: none;
+        }
+    }
+
+    .spineInner {
+        position: static;
+        max-height: none;
+    }
+
+    .cockpitContent {
+        padding: 0 0 dt.$spacing-2xl;
+    }
+}
 
 // ---- Shell layout ------------------------------------------
 .shell {
@@ -281,9 +418,9 @@ $rail: 3px; // severity spine / active accent width
 .groupLabel {
     font-size: dt.$font-size-2xs;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-weight: 700;
-    color: var(--bs-secondary-color);
+    letter-spacing: 0.1em;
+    font-weight: 600;
+    color: var(--bs-tertiary-color);
     padding: 0 dt.$spacing-sm dt.$spacing-xs;
 }
 
@@ -471,14 +608,21 @@ $rail: 3px; // severity spine / active accent width
     border-radius: dt.$radius-lg;
 }
 
+// The one pane anatomy: optional group eyebrow, a headline-weight title,
+// actions on the baseline, lede below. Structure comes from type scale and
+// space — no hairline underneath.
 .paneHeader {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
     gap: dt.$spacing-md;
     padding-bottom: dt.$spacing-md;
-    border-bottom: 1px solid rgba(var(--bs-border-color-rgb), 0.5);
     margin-bottom: dt.$spacing-xl;
+}
+
+.paneEyebrow {
+    @include board.board-eyebrow;
+    margin-bottom: dt.$spacing-xs;
 }
 
 .paneActions {
@@ -496,9 +640,10 @@ $rail: 3px; // severity spine / active accent width
 }
 
 .paneTitle {
-    font-size: dt.$font-size-lg;
+    font-size: dt.$font-size-2xl;
     font-weight: 700;
-    letter-spacing: -0.01em;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
     margin: 0;
 }
 
@@ -515,6 +660,10 @@ $rail: 3px; // severity spine / active accent width
 // unifying their cards + inputs with the console's token language.
 .content {
     padding: dt.$spacing-2xl;
+}
+
+.content,
+.cockpitContent {
     min-width: 0;
 
     :global(.bg-light-subtle) {


### PR DESCRIPTION
Full visual redesign of the /games-v2/[game]/manage console, extending the games-v2 board vocabulary (.interface-design/system.md) to the mod surfaces that never got the craft pass.

## Chrome
- The framed-box console is gone. New **cockpit** layout: a sidebar spine (game cover + name masthead → nav groups → exit doors) beside content sitting directly on the page canvas, one hairline between them. Mobile keeps the overlay drawer behind a slim topbar. Settings keeps its existing chrome untouched.
- One pane anatomy everywhere: group eyebrow (Queue/Structure/Game) over a headline-scale title, actions on the baseline, lede below.

## Panes
- **Overview** is now a control room: status headline (calm "All clear" or a severity-led count), mono KPI band, top needs-attention preview with severity spines, health + setup rail, import & sync card. The tile grid of nav duplicates is demoted to one quiet row.
- **Import from speedrun.com**: quiet dry-run note, composed fetch row, proper stat bands (fetched vs changed), status pills.
- **Needs attention / Bans**: triage rows refined; bans as a board table with a quiet destructive lift flow.
- **Boards** renders the real public LeaderboardTable with curation slots (quick-moderate, selection, add-runner ghost row).
- **Categories / Groups / Levels / Subcategories & filters / Game details / Theme / Moderators / roster / runner dossier**: all on the shared vocabulary (board surfaces, mono numerals, one-red/one-green, action hierarchy, voice rules).

## Verification
- `check-scss` compiles all 185 stylesheets; `tc-diff` shows no new type errors vs baseline.
- games-v2 tests: 955 passed; the 12 failures (row-actions ×10, level-picker ×2) fail identically on main. Four variables-grid selectors updated for the icon add buttons (same behavior, new accessible names).
- The 2 Biome lint errors are pre-existing on main.
- Note: the overview commit also carries the variables-grid restyle (staging mishap during a recovered parallel-work session; content is correct).

Not yet restyled (follow-up candidates): category detail page, history drawer internals, run page header scale, run-action-dialog.
