### PR TITLE
Hide level groups from the Category groups menu

### DIFF
--- a/app/(new-layout)/games-v2/[game]/manage/game-tab/game-tab.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/game-tab/game-tab.tsx
@@ -42,6 +42,11 @@ export function GameTab({
     onGroupsChange,
     onRowGroupChange,
 }: Props) {
+    // Levels are managed in the Levels menu, so keep level groups out of
+    // this pane. `groups` itself stays unfiltered — other consumers (e.g.
+    // CategoriesPane/splitLevelBoards) still need the level groups.
+    const normalGroups = groups.filter((group) => group.kind !== 'level');
+
     return (
         <section className={styles.surface}>
             <header className={styles.paneHeader}>
@@ -64,7 +69,7 @@ export function GameTab({
             />
             <GroupsSection
                 game={game}
-                groups={groups}
+                groups={normalGroups}
                 rows={rows}
                 snapshotGroups={boardGroups}
                 onGroupsChange={onGroupsChange}


### PR DESCRIPTION
Each level is stored as a category group (kind='level'). Levels are already managed separately in the Levels menu, so this filters kind==='level' groups out of the Category groups pane (GroupsSection) only. The groups list itself stays unfiltered — CategoriesPane/splitLevelBoards still get the full set.