### PR TITLE
Live-update the band preview on group collapse/display-mode changes

### DIFF
--- a/app/(new-layout)/games-v2/[game]/manage/game-tab/game-tab.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/game-tab/game-tab.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import styles from '~src/components/console-chrome/console.module.scss';
 import type { ManageCategoryRow, ManageGroup } from '~src/lib/category-mgmt';
 import { previewCategories } from '~src/lib/console/preview-categories';
@@ -42,10 +43,23 @@ export function GameTab({
     onGroupsChange,
     onRowGroupChange,
 }: Props) {
-    // Levels are managed in the Levels menu, so keep level groups out of
-    // this pane. `groups` itself stays unfiltered — other consumers (e.g.
-    // CategoriesPane/splitLevelBoards) still need the level groups.
-    const normalGroups = groups.filter((group) => group.kind !== 'level');
+    // The preview must reflect optimistic edits (collapsed/display-mode
+    // toggles), not just the immutable server snapshot in `boardGroups`, so
+    // overlay the live `groups` state onto it.
+    const previewGroups = useMemo(
+        () =>
+            boardGroups.map((bg) => {
+                const m = groups.find((g) => g.id === bg.id);
+                return m
+                    ? {
+                          ...bg,
+                          hiddenByDefault: m.hiddenByDefault,
+                          displayMode: m.displayMode,
+                      }
+                    : bg;
+            }),
+        [boardGroups, groups],
+    );
 
     return (
         <section className={styles.surface}>
@@ -65,13 +79,12 @@ export function GameTab({
                 does too. */}
             <CategoryBandPreview
                 categories={previewCategories(boardCategories, rows)}
-                groups={boardGroups}
+                groups={previewGroups}
             />
             <GroupsSection
                 game={game}
-                groups={normalGroups}
+                groups={groups}
                 rows={rows}
-                snapshotGroups={boardGroups}
                 onGroupsChange={onGroupsChange}
                 onRowGroupChange={onRowGroupChange}
             />

--- a/app/(new-layout)/games-v2/[game]/manage/game-tab/groups-section.test.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/game-tab/groups-section.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -26,35 +27,44 @@ vi.mock('react-toastify', () => ({
     toast: { error: mocks.toastError, success: vi.fn() },
 }));
 
+import type { ManageGroup } from '~src/lib/category-mgmt';
 import { GroupsSection } from './groups-section';
 
 const GAME = { id: 1, name: 'example-game', display: 'Example Game' } as never;
 
-function renderSection(hiddenByDefault: boolean) {
-    return render(
+const onGroupsChangeSpy = vi.fn();
+
+// Collapsed is now optimistic through onGroupsChange (like displayMode),
+// not a local set, so the harness needs to actually feed updated groups
+// back in for the checkbox to reflect the new state.
+function StatefulSection({ hiddenByDefault }: { hiddenByDefault: boolean }) {
+    const [groups, setGroups] = useState<ManageGroup[]>([
+        {
+            id: 5,
+            name: 'Main',
+            sortOrder: 1,
+            hiddenByDefault,
+            displayMode: null,
+            kind: 'normal',
+            rules: null,
+        },
+    ]);
+    return (
         <GroupsSection
             game={GAME}
-            groups={[
-                {
-                    id: 5,
-                    name: 'Main',
-                    sortOrder: 1,
-                    hiddenByDefault,
-                    displayMode: null,
-                    kind: 'normal',
-                    rules: null,
-                },
-            ]}
+            groups={groups}
             rows={[]}
-            snapshotGroups={
-                [
-                    { id: 5, name: 'Main', sortOrder: 1, hiddenByDefault },
-                ] as never
-            }
-            onGroupsChange={vi.fn()}
+            onGroupsChange={(next) => {
+                onGroupsChangeSpy(next);
+                setGroups(next);
+            }}
             onRowGroupChange={vi.fn()}
-        />,
+        />
     );
+}
+
+function renderSection(hiddenByDefault: boolean) {
+    return render(<StatefulSection hiddenByDefault={hiddenByDefault} />);
 }
 
 afterEach(() => {
@@ -63,7 +73,7 @@ afterEach(() => {
 });
 
 describe('GroupsSection — collapsed by default', () => {
-    it('reads the flag from the snapshot, which ManageGroup does not carry', () => {
+    it('reads the flag straight off the group', () => {
         renderSection(true);
         const box = screen.getByLabelText(
             'Collapsed by default',
@@ -71,10 +81,13 @@ describe('GroupsSection — collapsed by default', () => {
         expect(box.checked).toBe(true);
     });
 
-    it('writes the flag — the console could not reach it before', () => {
+    it('writes the flag optimistically through onGroupsChange', () => {
         renderSection(false);
         fireEvent.click(screen.getByLabelText('Collapsed by default'));
 
+        expect(onGroupsChangeSpy).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 5, hiddenByDefault: true }),
+        ]);
         expect(mocks.setGroupHiddenAction).toHaveBeenCalledWith({
             gameSlug: 'example-game',
             gameId: 1,

--- a/app/(new-layout)/games-v2/[game]/manage/game-tab/groups-section.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/game-tab/groups-section.tsx
@@ -21,7 +21,6 @@ import type { ManageCategoryRow, ManageGroup } from '~src/lib/category-mgmt';
 import type {
     CategoryDisplayMode,
     ResolvedGame,
-    ResolvedGroup,
 } from '../../../../../../types/leaderboards.types';
 import { ConfirmDialog } from '../../shared/confirm-dialog';
 import styles from './groups-section.module.scss';
@@ -30,9 +29,6 @@ interface Props {
     game: ResolvedGame;
     groups: ManageGroup[];
     rows: ManageCategoryRow[];
-    /** Server snapshot, for the one field ManageGroup doesn't carry:
-     *  `hiddenByDefault`. */
-    snapshotGroups: ResolvedGroup[];
     onGroupsChange: (groups: ManageGroup[]) => void;
     onRowGroupChange: (
         categoryId: number,
@@ -45,7 +41,6 @@ export function GroupsSection({
     game,
     groups,
     rows,
-    snapshotGroups,
     onGroupsChange,
     onRowGroupChange,
 }: Props) {
@@ -59,26 +54,16 @@ export function GroupsSection({
         useState<ManageGroup | null>(null);
     const [deleteError, setDeleteError] = useState<string | null>(null);
 
-    // The flag lives on ResolvedGroup, not on the console's ManageGroup, so
-    // it is tracked here as a set of ids seeded from the snapshot. Optimistic:
-    // the checkbox flips first and reverts if the write fails, because the
-    // only feedback otherwise is the band preview above redrawing a beat late.
-    const [hidden, setHiddenIds] = useState<Set<number>>(
-        () =>
-            new Set(
-                snapshotGroups
-                    .filter((g) => g.hiddenByDefault)
-                    .map((g) => g.id),
-            ),
-    );
-
+    // Optimistic for the same reason displayMode below is: the checkbox
+    // flips first and reverts if the write fails, because the only other
+    // feedback is the band preview above redrawing a beat late.
     const setHidden = (group: ManageGroup, hiddenByDefault: boolean) => {
-        setHiddenIds((prev) => {
-            const next = new Set(prev);
-            if (hiddenByDefault) next.add(group.id);
-            else next.delete(group.id);
-            return next;
-        });
+        const previous = group.hiddenByDefault;
+        onGroupsChange(
+            groups.map((x) =>
+                x.id === group.id ? { ...x, hiddenByDefault } : x,
+            ),
+        );
         startTransition(async () => {
             const res = await setGroupHiddenAction({
                 gameSlug: game.name,
@@ -88,12 +73,13 @@ export function GroupsSection({
             });
             if ('error' in res) {
                 toast.error(res.error);
-                setHiddenIds((prev) => {
-                    const next = new Set(prev);
-                    if (hiddenByDefault) next.delete(group.id);
-                    else next.add(group.id);
-                    return next;
-                });
+                onGroupsChange(
+                    groups.map((x) =>
+                        x.id === group.id
+                            ? { ...x, hiddenByDefault: previous }
+                            : x,
+                    ),
+                );
             }
         });
     };
@@ -125,6 +111,15 @@ export function GroupsSection({
             }
         });
     };
+
+    // Levels are managed in the Levels menu, so keep level groups out of
+    // this list. `groups` itself stays unfiltered — the mutation handlers
+    // above operate on it directly so level groups are never dropped from
+    // the console's group state.
+    const listGroups = useMemo(
+        () => groups.filter((g) => g.kind !== 'level'),
+        [groups],
+    );
 
     const countByGroupId = useMemo(() => {
         const m = new Map<number, number>();
@@ -319,7 +314,7 @@ export function GroupsSection({
                     </button>
                 </div>
 
-                {groups.length === 0 ? (
+                {listGroups.length === 0 ? (
                     <div className={styles.empty}>
                         <Collection
                             size={26}
@@ -334,7 +329,7 @@ export function GroupsSection({
                     </div>
                 ) : (
                     <ul className={styles.list}>
-                        {groups.map((g, i) => {
+                        {listGroups.map((g, i) => {
                             const count = countByGroupId.get(g.id) ?? 0;
                             const isEditing = editingId === g.id;
                             return (
@@ -374,7 +369,7 @@ export function GroupsSection({
                                             onClick={() => moveBy(g.id, 1)}
                                             disabled={
                                                 pending ||
-                                                i === groups.length - 1
+                                                i === listGroups.length - 1
                                             }
                                             aria-label={`Move ${g.name} down`}
                                         >
@@ -437,7 +432,7 @@ export function GroupsSection({
                                             <input
                                                 type="checkbox"
                                                 className="form-check-input mt-0"
-                                                checked={hidden.has(g.id)}
+                                                checked={g.hiddenByDefault}
                                                 disabled={pending}
                                                 // The visible word is short so
                                                 // the control row stays calm;


### PR DESCRIPTION
the Category groups band preview rendered from the immutable boardGroups snapshot, so toggling a group's Collapsed checkbox (which only updated a local set) didn't update it live. Now the collapsed toggle is optimistic via onGroupsChange like display-mode already is, and the preview renders boardGroups overlaid with the optimistic manageGroups values. Also moved the level-group list filter into GroupsSection so group edits no longer drop level groups from console state. Files: game-tab.tsx, groups-section.tsx.