### PR TITLE
Clearer Levels pane: one board list per level

### DIFF
--- a/app/(new-layout)/games-v2/[game]/manage/levels/level-row.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/levels/level-row.tsx
@@ -23,10 +23,11 @@ interface Props {
 }
 
 /**
- * One level: its name, its rules, and the checklist of level categories that
- * do (or deliberately don't) get a board on it. The checklist is the whole
- * point of the row — a level's boards are materialised from the templates, so
- * the only per-level decision is which templates it opts out of.
+ * One level: its name, its rules, and the boards it carries. A level's
+ * boards are materialised from the shared level templates, so the row's
+ * whole job is showing — per board — whether it's on, whether it matches the
+ * shared template or was customized away from it, and letting the moderator
+ * flip it or restore it.
  */
 export function LevelRow({
     gameId,
@@ -54,8 +55,12 @@ export function LevelRow({
 
     const instanceFor = (templateId: number) =>
         level.instances.find((i) => i.templateId === templateId) ?? null;
+    // Boards with no template of their own — templates.map() below never
+    // reaches these, so they get their own pass.
     const levelOnly = level.instances.filter((i) => i.state === 'level-only');
-    const overridden = level.instances.filter((i) => i.state === 'overridden');
+    const boardCount = level.instances.filter(
+        (i) => i.state !== 'excluded',
+    ).length;
 
     const saveName = () => {
         const trimmed = name.trim();
@@ -109,6 +114,7 @@ export function LevelRow({
     return (
         <div className={styles.levelRow}>
             <div className={styles.levelHead}>
+                <span className={styles.levelMark}>Level</span>
                 <input
                     className={`form-control form-control-sm ${styles.nameInput}`}
                     aria-label={`Name of ${level.name}`}
@@ -118,11 +124,7 @@ export function LevelRow({
                     onBlur={saveName}
                 />
                 <span className={styles.count}>
-                    {
-                        level.instances.filter((i) => i.state !== 'excluded')
-                            .length
-                    }{' '}
-                    boards
+                    {boardCount} board{boardCount === 1 ? '' : 's'}
                 </span>
                 <button
                     type="button"
@@ -157,64 +159,95 @@ export function LevelRow({
                 </div>
             )}
 
-            <div className={styles.checklist}>
+            <div className={styles.boards}>
+                <div className={styles.boardsLabel}>Boards on this level</div>
+
                 {templates.map((t) => {
                     const instance = instanceFor(t.id);
                     const on =
                         instance != null && instance.state !== 'excluded';
-                    return (
-                        <label key={t.id} className={styles.check}>
-                            <input
-                                type="checkbox"
-                                className="form-check-input"
-                                aria-label={`${t.display} on ${level.name}`}
-                                checked={on}
-                                disabled={isPending}
-                                onChange={() => toggleTemplate(t.id, on)}
-                            />
-                            {t.display}
-                        </label>
-                    );
-                })}
-            </div>
+                    const customized = on && instance?.state === 'overridden';
 
-            {(overridden.length > 0 || levelOnly.length > 0) && (
-                <ul className={styles.instanceList}>
-                    {overridden.map((i) => (
-                        <li key={i.categoryId} className={styles.instanceRow}>
-                            <Link href={categoryHref(i.categoryId)}>
-                                {i.display}
-                            </Link>
-                            <span
-                                className={`${styles.pill} ${styles.pillOverridden}`}
-                            >
-                                edited here
-                            </span>
+                    return (
+                        <div
+                            key={t.id}
+                            className={`${styles.board} ${on ? '' : styles.boardOff}`}
+                        >
                             <button
                                 type="button"
-                                className={styles.pillAction}
-                                aria-label={`Resync ${i.display} on ${level.name}`}
+                                role="switch"
+                                aria-checked={on}
+                                aria-label={`${t.display} on ${level.name}`}
                                 disabled={isPending}
-                                onClick={() => resync(i.categoryId)}
-                            >
-                                Resync
-                            </button>
-                        </li>
-                    ))}
-                    {levelOnly.map((i) => (
-                        <li key={i.categoryId} className={styles.instanceRow}>
-                            <Link href={categoryHref(i.categoryId)}>
-                                {i.display}
-                            </Link>
-                            <span
-                                className={`${styles.pill} ${styles.pillLevelOnly}`}
-                            >
-                                only on this level
+                                className={styles.boardToggle}
+                                onClick={() => toggleTemplate(t.id, on)}
+                            />
+                            <span className={styles.boardName}>
+                                <strong>{t.display}</strong> board
                             </span>
-                        </li>
-                    ))}
-                </ul>
-            )}
+                            <span
+                                className={`${styles.chip} ${
+                                    !on
+                                        ? styles.chipOff
+                                        : customized
+                                          ? styles.chipCustom
+                                          : styles.chipDefault
+                                }`}
+                            >
+                                {!on
+                                    ? 'Off'
+                                    : customized
+                                      ? 'Customized'
+                                      : 'Default'}
+                            </span>
+                            <span className={styles.boardActions}>
+                                {customized && instance != null && (
+                                    <button
+                                        type="button"
+                                        className={styles.resyncAction}
+                                        aria-label={`Restore ${t.display} on ${level.name} to the template`}
+                                        disabled={isPending}
+                                        onClick={() =>
+                                            resync(instance.categoryId)
+                                        }
+                                    >
+                                        Restore to template
+                                    </button>
+                                )}
+                                {instance?.categoryId != null && (
+                                    <Link
+                                        className={styles.editAction}
+                                        href={categoryHref(instance.categoryId)}
+                                    >
+                                        Edit
+                                    </Link>
+                                )}
+                            </span>
+                        </div>
+                    );
+                })}
+
+                {levelOnly.map((i) => (
+                    <div key={i.categoryId} className={styles.board}>
+                        <span
+                            className={styles.boardToggleSpacer}
+                            aria-hidden="true"
+                        />
+                        <span className={styles.boardName}>{i.display}</span>
+                        <span className={`${styles.chip} ${styles.chipOnly}`}>
+                            Only on this level
+                        </span>
+                        <span className={styles.boardActions}>
+                            <Link
+                                className={styles.editAction}
+                                href={categoryHref(i.categoryId)}
+                            >
+                                Edit
+                            </Link>
+                        </span>
+                    </div>
+                ))}
+            </div>
 
             <InlineError>{error}</InlineError>
         </div>

--- a/app/(new-layout)/games-v2/[game]/manage/levels/levels-pane.test.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/levels/levels-pane.test.tsx
@@ -134,7 +134,9 @@ describe('LevelsPane', () => {
         expect(screen.getByDisplayValue('Marble Zone')).toBeTruthy();
         // The level-only board is called out as belonging to this level only.
         expect(screen.getByText('Bonus stage')).toBeTruthy();
-        expect(screen.getByText(/only on this level/i)).toBeTruthy();
+        expect(
+            screen.getAllByText(/only on this level/i).length,
+        ).toBeGreaterThan(0);
         expect(mocks.levelOverviewAction).toHaveBeenCalledWith(GAME);
     });
 
@@ -142,11 +144,9 @@ describe('LevelsPane', () => {
         mocks.levelOverviewAction.mockResolvedValue({ result: OVERVIEW });
         renderPane();
 
-        const box = (await screen.findByLabelText(
-            'Any% on Green Hill',
-        )) as HTMLInputElement;
-        expect(box.checked).toBe(true);
-        fireEvent.click(box);
+        const toggle = await screen.findByLabelText('Any% on Green Hill');
+        expect(toggle.getAttribute('aria-checked')).toBe('true');
+        fireEvent.click(toggle);
 
         await waitFor(() => {
             expect(mocks.levelOpAction).toHaveBeenCalledWith({
@@ -183,12 +183,12 @@ describe('LevelsPane', () => {
         });
     });
 
-    it('offers Resync on an overridden board', async () => {
+    it('offers to restore an overridden board to its template', async () => {
         mocks.levelOverviewAction.mockResolvedValue({ result: OVERVIEW });
         renderPane();
 
         const resync = await screen.findByRole('button', {
-            name: 'Resync 100% on Green Hill',
+            name: 'Restore 100% on Green Hill to the template',
         });
         fireEvent.click(resync);
 

--- a/app/(new-layout)/games-v2/[game]/manage/levels/levels-pane.tsx
+++ b/app/(new-layout)/games-v2/[game]/manage/levels/levels-pane.tsx
@@ -91,9 +91,39 @@ export function LevelsPane({ gameId, gameSlug, templates }: Props) {
                 )}
             </header>
             <p className={consoleStyles.paneLede}>
-                Name each level, set its rules, and choose which level
-                categories it carries.
+                Each row is a level. A level&apos;s boards come from the shared
+                level categories — toggle which boards each level carries, and
+                restore any that were customized.
             </p>
+
+            {levels.length > 0 && (
+                <div className={styles.legend}>
+                    <span className={styles.legendItem}>
+                        <span
+                            className={`${styles.legendDot} ${styles.legendDotDefault}`}
+                        />
+                        On · matches the shared template
+                    </span>
+                    <span className={styles.legendItem}>
+                        <span
+                            className={`${styles.legendDot} ${styles.legendDotCustom}`}
+                        />
+                        Customized · edited on this level only
+                    </span>
+                    <span className={styles.legendItem}>
+                        <span
+                            className={`${styles.legendDot} ${styles.legendDotOnly}`}
+                        />
+                        Only on this level · no template
+                    </span>
+                    <span className={styles.legendItem}>
+                        <span
+                            className={`${styles.legendDot} ${styles.legendDotOff}`}
+                        />
+                        Off · not carried by this level
+                    </span>
+                </div>
+            )}
 
             <InlineError>{error}</InlineError>
 

--- a/app/(new-layout)/games-v2/[game]/manage/levels/levels.module.scss
+++ b/app/(new-layout)/games-v2/[game]/manage/levels/levels.module.scss
@@ -36,9 +36,11 @@
     color: var(--bs-secondary-color);
 }
 
-.pillLevelOnly {
-    background: rgba(var(--bs-primary-rgb), 0.12);
-    color: var(--bs-primary);
+.check {
+    display: flex;
+    align-items: center;
+    gap: dt.$spacing-xs;
+    font-size: dt.$font-size-sm;
 }
 
 .levelRow {
@@ -67,34 +69,200 @@
     @include board.board-input-rules;
 }
 
-.checklist {
-    display: flex;
-    flex-wrap: wrap;
-    gap: dt.$spacing-md;
-    margin-top: dt.$spacing-sm;
+// ---- Level tag ------------------------------------------------
+// A quiet eyebrow badge on the level head so the row reads as a level,
+// not a category — otherwise the name input alone looks interchangeable
+// with a category row.
+.levelMark {
+    @include board.board-eyebrow;
+    flex: none;
+    color: var(--bs-primary);
+    background: rgba(var(--bs-primary-rgb), 0.1);
+    border: 1px solid rgba(var(--bs-primary-rgb), 0.28);
+    padding: dt.$spacing-xs dt.$spacing-sm;
+    border-radius: dt.$radius-sm;
 }
 
-.check {
+// ---- Boards on this level --------------------------------------
+// One unified list replaces the old template checklist + separate
+// overridden/level-only pill list, so a customized board appears once.
+.boards {
+    margin-top: dt.$spacing-sm;
+    padding-top: dt.$spacing-xs;
+    border-top: 1px solid rgba(var(--bs-border-color-rgb), 0.3);
+}
+
+.boardsLabel {
+    @include board.board-eyebrow;
+    padding: dt.$spacing-sm dt.$spacing-xs dt.$spacing-xs;
+}
+
+.board {
     display: flex;
     align-items: center;
-    gap: dt.$spacing-xs;
-    font-size: dt.$font-size-sm;
+    gap: dt.$spacing-md;
+    padding: dt.$spacing-xs dt.$spacing-xs;
+    border-radius: dt.$radius-md;
+
+    & + & {
+        border-top: 1px solid rgba(var(--bs-border-color-rgb), 0.15);
+    }
+
+    &:hover {
+        background: rgba(var(--bs-body-color-rgb), 0.03);
+    }
 }
 
-.instanceList {
-    margin: dt.$spacing-sm 0 0;
-    padding: 0;
-    list-style: none;
-    display: flex;
-    flex-direction: column;
-    gap: dt.$spacing-xs;
-    font-size: dt.$font-size-sm;
+.boardOff {
+    .boardName {
+        color: var(--bs-secondary-color);
+    }
 }
 
-.instanceRow {
+.boardToggle {
+    @include board.board-switch;
+}
+
+// Keeps level-only rows (no template, so no toggle) aligned with the
+// toggled rows above/below them.
+.boardToggleSpacer {
+    display: inline-block;
+    width: 32px;
+    flex: none;
+}
+
+.boardName {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: dt.$font-size-sm;
+
+    strong {
+        font-weight: 600;
+    }
+}
+
+.boardActions {
     display: flex;
     align-items: center;
     gap: dt.$spacing-sm;
+    flex: none;
+}
+
+.resyncAction {
+    background: transparent;
+    border: 1px solid
+        color-mix(in srgb, #{dt.$accent-amber} 45%, transparent);
+    color: dt.$accent-amber;
+    font-size: dt.$font-size-2xs;
+    font-weight: 500;
+    padding: 0.2rem dt.$spacing-sm;
+    border-radius: dt.$radius-sm;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background-color dt.$transition-fast;
+
+    &:hover {
+        background: color-mix(in srgb, #{dt.$accent-amber} 12%, transparent);
+    }
+
+    &:focus-visible {
+        outline: 2px solid rgba(var(--bs-primary-rgb), 0.5);
+        outline-offset: 1px;
+    }
+
+    &:disabled {
+        opacity: 0.6;
+        cursor: default;
+    }
+}
+
+.editAction {
+    @include board.board-quiet-link;
+    color: var(--bs-primary);
+    font-size: dt.$font-size-2xs;
+    font-weight: 500;
+    padding: 0.2rem dt.$spacing-xs;
+
+    &:hover {
+        color: var(--bs-primary);
+        text-decoration: underline;
+    }
+}
+
+// ---- State chips -------------------------------------------------
+// One state colour per board, so the list can be scanned for the odd
+// one out without reading every label.
+.chip {
+    @include board.board-pill;
+    flex: none;
+}
+
+.chipDefault {
+    background: rgba(var(--bs-secondary-rgb), 0.12);
+    color: var(--bs-secondary-color);
+}
+
+.chipCustom {
+    background: color-mix(in srgb, #{dt.$accent-amber} 16%, transparent);
+    color: dt.$accent-amber;
+    border-color: color-mix(in srgb, #{dt.$accent-amber} 45%, transparent);
+}
+
+.chipOnly {
+    background: rgba(var(--bs-primary-rgb), 0.12);
+    color: var(--bs-primary);
+    border-color: rgba(var(--bs-primary-rgb), 0.4);
+}
+
+.chipOff {
+    background: transparent;
+    color: var(--bs-tertiary-color);
+    border-color: rgba(var(--bs-border-color-rgb), 0.6);
+    border-style: dashed;
+}
+
+// ---- Pane legend --------------------------------------------------
+.legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: dt.$spacing-xs dt.$spacing-lg;
+    padding: dt.$spacing-sm dt.$spacing-md;
+    background: rgba(var(--bs-body-color-rgb), 0.03);
+    border: 1px solid rgba(var(--bs-border-color-rgb), 0.35);
+    border-radius: dt.$radius-md;
+    margin: dt.$spacing-sm 0 dt.$spacing-md;
+}
+
+.legendItem {
+    display: flex;
+    align-items: center;
+    gap: dt.$spacing-xs;
+    font-size: dt.$font-size-2xs;
+    color: var(--bs-secondary-color);
+}
+
+.legendDot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex: none;
+}
+
+.legendDotDefault {
+    background: var(--bs-tertiary-color);
+}
+
+.legendDotCustom {
+    background: dt.$accent-amber;
+}
+
+.legendDotOnly {
+    background: var(--bs-primary);
+}
+
+.legendDotOff {
+    background: transparent;
+    border: 1px solid var(--bs-tertiary-color);
 }
 
 .rulesToggle {


### PR DESCRIPTION
what/why: the Levels pane showed a template checklist AND a separate overridden/level-only pill list, so a customized board appeared twice and the "Level" checkbox read as circular. Redesign: one "Boards on this level" list per level - a labeled toggle per board, a single state chip (Default / Customized / Only on this level / Off), "Restore to template" for customized boards, a LEVEL tag on each row, and a pane explainer + legend. Same actions/data underneath (rename, rules, include/exclude, resync, edit).