### PR TITLE
Leaderboard: hide milliseconds when no time on the page has any

### DIFF
--- a/app/(new-layout)/games-v2/[game]/leaderboard/leaderboard-table.tsx
+++ b/app/(new-layout)/games-v2/[game]/leaderboard/leaderboard-table.tsx
@@ -184,6 +184,17 @@ export function LeaderboardTable({
         hideRealTime || (secondary.key === 'rt' && secondaryAllNull);
     const rowHideGameTime =
         hideGameTime || (secondary.key === 'gt' && secondaryAllNull);
+    // Boards imported from speedrun.com often hold only whole-second times;
+    // printing ".000" on every row is noise, so milliseconds show only when
+    // at least one loaded time actually has them. Recomputed per page, same
+    // as the secondary column.
+    const boardShowMilliseconds =
+        showMilliseconds &&
+        leaderboard.entries.some((e) =>
+            [e.realTime, e.gameTime].some(
+                (t) => t != null && Math.round(t) % 1000 !== 0,
+            ),
+        );
 
     return (
         <div className={styles.wrapper}>
@@ -257,7 +268,7 @@ export function LeaderboardTable({
                             hideGameTime={rowHideGameTime}
                             primaryTiming={primaryTiming}
                             valueColumns={visibleValueColumns}
-                            showMilliseconds={showMilliseconds}
+                            showMilliseconds={boardShowMilliseconds}
                             gameTimeLabel={gameTimeLabel}
                             rtaFallback={rtaFallback}
                             selected={(() => {


### PR DESCRIPTION
Boards imported from speedrun.com (e.g. Spyro the Dragon Any%) have show milliseconds on because the game's SRC ruleset does, but every run on them is whole seconds. We printed `.000` on every row; speedrun.com shows none.

The leaderboard table now shows milliseconds only when the category flag is on **and** at least one loaded time (RT or GT) has a non-zero millisecond part. Recomputed per page, same as the secondary-time column. Boards with real millisecond times are unchanged; the flag still turns them off entirely.