### PR TITLE
Overview: drop .000 from whole-second category records

### DIFF
--- a/app/(new-layout)/games-v2/[game]/overview/category-card.tsx
+++ b/app/(new-layout)/games-v2/[game]/overview/category-card.tsx
@@ -87,9 +87,12 @@ export function CategoryCard({ gameSlug, card, index }: Props) {
                 {wr ? (
                     <div className={styles.record}>
                         <span className={styles.recordTime}>
+                            {/* Same rule as the board: a whole-second record
+                                (common on speedrun.com imports) drops ".000". */}
                             {formatRecord(
                                 wr.time as number,
-                                category.showMilliseconds ?? true,
+                                (category.showMilliseconds ?? true) &&
+                                    Math.round(Number(wr.time)) % 1000 !== 0,
                             )}
                         </span>
                         <span className={styles.recordHolder}>


### PR DESCRIPTION
Follow-up to #409. The category overview cards format the world record with the category's show milliseconds flag alone, so speedrun.com-imported boards (e.g. Spyro the Dragon Any%) still showed `36:21.000` there.

The card now shows milliseconds only when the flag is on **and** the record has a non-zero millisecond part. Podium times on the card already never show milliseconds.